### PR TITLE
Optimize agent configuration retrieval

### DIFF
--- a/src/Aevatar.Application/Common/GuidUtil.cs
+++ b/src/Aevatar.Application/Common/GuidUtil.cs
@@ -14,4 +14,9 @@ public class GuidUtil
             return new Guid(hash);
         }
     }
+
+    public static string GuidToGrainKey(Guid primaryKey)
+    {
+        return primaryKey.ToString("N");
+    }
 }

--- a/src/Aevatar.Application/Service/AgentService.cs
+++ b/src/Aevatar.Application/Service/AgentService.cs
@@ -39,9 +39,6 @@ public class AgentService : ApplicationService, IAgentService
     private readonly GrainTypeResolver _grainTypeResolver;
     private readonly ISchemaProvider _schemaProvider;
 
-    private const string IndexSuffix = "index";
-    private const string IndexPrefix = "aevatar";
-
     public AgentService(
         IClusterClient clusterClient,
         ICQRSProvider cqrsProvider,
@@ -103,7 +100,7 @@ public class AgentService : ApplicationService, IAgentService
         }
     }
 
-    public async Task<Dictionary<string, AgentTypeData?>> GetAgentTypeDataMap()
+    private async Task<Dictionary<string, AgentTypeData?>> GetAgentTypeDataMap()
     {
         var systemAgents = _agentOptions.CurrentValue.SystemAgentList;
         var availableGAgents = _gAgentManager.GetAvailableGAgentTypes();
@@ -121,7 +118,7 @@ public class AgentService : ApplicationService, IAgentService
                 {
                     FullName = agentType.FullName,
                 };
-                var grainId = GrainId.Create(grainType, Guid.NewGuid().ToString());
+                var grainId = GrainId.Create(grainType, GuidUtil.GuidToGrainKey(GuidUtil.StringToGuid("AgentDefaultId"))); // make sure only one agent instance for each type
                 var agent = await _gAgentFactory.GetGAgentAsync(grainId);
                 var initializeDtoType = await agent.GetConfigurationTypeAsync();
                 if (initializeDtoType == null || initializeDtoType.IsAbstract)
@@ -134,7 +131,7 @@ public class AgentService : ApplicationService, IAgentService
                     initializeDtoType.GetProperties(BindingFlags.Public | BindingFlags.Instance |
                                                     BindingFlags.DeclaredOnly);
 
-                var initializationData = new InitializationData
+                var initializationData = new Configuration
                 {
                     DtoType = initializeDtoType
                 };
@@ -159,6 +156,38 @@ public class AgentService : ApplicationService, IAgentService
         return dict;
     }
 
+    private async Task<Configuration?> GetAgentConfigurationAsync(IGAgent agent)
+    {
+        var configurationType = await agent.GetConfigurationTypeAsync();
+        if (configurationType == null || configurationType.IsAbstract)
+        {
+            return null;
+        }
+
+        PropertyInfo[] properties =
+            configurationType.GetProperties(BindingFlags.Public | BindingFlags.Instance |
+                                            BindingFlags.DeclaredOnly);
+
+        var configuration = new Configuration
+        {
+            DtoType = configurationType
+        };
+
+        var propertyDtos = new List<PropertyData>();
+        foreach (PropertyInfo property in properties)
+        {
+            var propertyDto = new PropertyData()
+            {
+                Name = property.Name,
+                Type = property.PropertyType
+            };
+            propertyDtos.Add(propertyDto);
+        }
+
+        configuration.Properties = propertyDtos;
+        return configuration;
+    }
+    
     public async Task<List<AgentTypeDto>> GetAllAgents()
     {
         var propertyDtos = await GetAgentTypeDataMap();
@@ -193,10 +222,10 @@ public class AgentService : ApplicationService, IAgentService
         return resp;
     }
 
-    private ConfigurationBase SetupInitializedConfig(InitializationData initializationData,
+    private ConfigurationBase SetupConfigurationData(Configuration configuration,
         string propertiesString)
     {
-        var actualDto = Activator.CreateInstance(initializationData.DtoType);
+        var actualDto = Activator.CreateInstance(configuration.DtoType);
 
         var config = (ConfigurationBase)actualDto!;
         var schema = _schemaProvider.GetTypeSchema(config.GetType());
@@ -207,7 +236,7 @@ public class AgentService : ApplicationService, IAgentService
             throw new ParameterValidateException(validateDic);
         }
 
-        config = JsonConvert.DeserializeObject(propertiesString, initializationData.DtoType) as ConfigurationBase;
+        config = JsonConvert.DeserializeObject(propertiesString, configuration.DtoType) as ConfigurationBase;
         if (config == null)
         {
             throw new BusinessException("[AgentService][SetupInitializedConfig] config convert error");
@@ -291,24 +320,17 @@ public class AgentService : ApplicationService, IAgentService
     private async Task<IGAgent> InitializeBusinessAgent(Guid primaryKey, string agentType,
         string agentProperties)
     {
-        var agentTypeDataMap = await GetAgentTypeDataMap();
-        ConfigurationBase? config = null;
-
-        if (agentTypeDataMap.TryGetValue(agentType, out var agentTypeData) && !agentProperties.IsNullOrEmpty())
-        {
-            if (agentTypeData != null && agentTypeData.InitializationData != null)
-            {
-                config = SetupInitializedConfig(agentTypeData.InitializationData, agentProperties);
-            }
-        }
-
-        var grainId = GrainId.Create(agentType, primaryKey.ToString("N"));
+        var grainId = GrainId.Create(agentType, GuidUtil.GuidToGrainKey(primaryKey));
         var businessAgent = await _gAgentFactory.GetGAgentAsync(grainId);
-        if (config != null)
-        {
-            await businessAgent.ConfigAsync(config);
-        }
 
+        var initializationData = await GetAgentConfigurationAsync(businessAgent);
+        if (initializationData != null && !agentProperties.IsNullOrEmpty())
+        {
+            var config = SetupConfigurationData(initializationData, agentProperties);
+            await businessAgent.ConfigAsync(config);
+            
+        }
+        
         return businessAgent;
     }
 
@@ -324,21 +346,17 @@ public class AgentService : ApplicationService, IAgentService
         if (!dto.Properties.IsNullOrEmpty())
         {
             var updatedParam = JsonConvert.SerializeObject(dto.Properties);
-            var agentTypeDataMap = await GetAgentTypeDataMap();
-            ConfigurationBase? config = null;
-            if (agentTypeDataMap.TryGetValue(agentState.AgentType, out var agentTypeData) &&
-                !updatedParam.IsNullOrEmpty())
+            var configuration = await GetAgentConfigurationAsync(businessAgent);
+            if (configuration != null && !updatedParam.IsNullOrEmpty())
             {
-                if (agentTypeData != null && agentTypeData.InitializationData != null)
-                {
-                    config = SetupInitializedConfig(agentTypeData.InitializationData, updatedParam);
-                }
-            }
-
-            if (config != null)
-            {
+                var config = SetupConfigurationData(configuration, updatedParam);
                 await businessAgent.ConfigAsync(config);
-                await creatorAgent.UpdateAgentAsync(new UpdateAgentInput(){Name = dto.Name, Properties = JsonConvert.SerializeObject(dto.Properties)});
+                await creatorAgent.UpdateAgentAsync(new UpdateAgentInput
+                {
+                    Name = dto.Name, 
+                    Properties = JsonConvert.SerializeObject(dto.Properties)
+                });
+            
             }
             else
             {
@@ -375,15 +393,13 @@ public class AgentService : ApplicationService, IAgentService
             Properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(agentState.Properties),
             AgentGuid = agentState.BusinessAgentGrainId.GetGuidKey()
         };
-
-        var agentTypeDataMap = await GetAgentTypeDataMap();
-        if (agentTypeDataMap.TryGetValue(agentState.AgentType, out var agentTypeData))
+        
+        var businessAgent = await _gAgentFactory.GetGAgentAsync(agentState.BusinessAgentGrainId);
+        
+        var configuration = await GetAgentConfigurationAsync(businessAgent);
+        if (configuration != null)
         {
-            if (agentTypeData != null && agentTypeData.InitializationData != null)
-            {
-                resp.PropertyJsonSchema =
-                    _schemaProvider.GetTypeSchema(agentTypeData.InitializationData.DtoType).ToJson();
-            }
+            resp.PropertyJsonSchema = _schemaProvider.GetTypeSchema(configuration.DtoType).ToJson();
         }
 
         return resp;

--- a/src/Aevatar.Domain/Agent/AgentTypeDto.cs
+++ b/src/Aevatar.Domain/Agent/AgentTypeDto.cs
@@ -18,7 +18,7 @@ public class ParamDto
 }
 
 
-public class InitializationData
+public class Configuration
 {
     public Type DtoType { get; set; }
     public List<PropertyData> Properties { get; set; }
@@ -28,7 +28,7 @@ public class InitializationData
 public class AgentTypeData
 {
     public string? FullName { get; set; }
-    public InitializationData? InitializationData { get; set; } 
+    public Configuration? InitializationData { get; set; } 
 }
 
 public class PropertyData


### PR DESCRIPTION
1.Add GetAgentConfigurationAsync to get configuration from an existing agent instead of creating a new one.
2.Create only one instance for each agent type in GetAgentTypeDataMap method.
3.Add GuidToGrainKey method to get grain key from the primary key.