### PR TITLE
[Feature] Enable multiple projector per agent state type 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AbpVersion>9.0.3</AbpVersion>
     <OrleansVerion>9.0.1</OrleansVerion>
-    <AevatarVerion>1.4.13-alpha.1</AevatarVerion>
+    <AevatarVerion>1.5.0-alpha.5</AevatarVerion>
     <AevatarGAgentVerion>1.4.16-alpha-9+twitter1</AevatarGAgentVerion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description 
Support more projector to improve the throughput when processing state change events. Changes are :
1. Enable version check during elasticsearch indexing
2. Create multiple projector during silo startup

### Test
- During debug mode modify version so that it is less or equal to current version number. Observe if index is updated
<img width="639" alt="Screenshot 2025-04-30 at 15 52 17" src="https://github.com/user-attachments/assets/0a231bbc-08bc-46f0-a173-8acd5a37d34c" />
- Projector start 8 instances per agent state type
<img width="1658" alt="Screenshot 2025-04-30 at 15 53 17" src="https://github.com/user-attachments/assets/0aafe512-98b4-4853-84da-e8caf67443a9" />
