### PR TITLE
[Feature] Filter view change during activation and Ignore duplicated state change notification from Orleans

### DIFF
--- a/framework/src/Aevatar.EventSourcing.MongoDB/MongoDbLogConsistentStorage.cs
+++ b/framework/src/Aevatar.EventSourcing.MongoDB/MongoDbLogConsistentStorage.cs
@@ -176,6 +176,9 @@ public class MongoDbLogConsistentStorage : ILogConsistentStorage, ILifecyclePart
                     $"Version conflict ({nameof(AppendAsync)}): ServiceId={_serviceId} ProviderName={_name} GrainType={grainTypeName} GrainId={grainId} Version={expectedVersion}.");
             }
 
+            _logger.LogInformation("AppendAsync: ServiceId={ServiceId} ProviderName={ProviderName} GrainType={GrainType} GrainId={GrainId} ExpectedVersion={ExpectedVersion} CurrentVersion={CurrentVersion}",
+                _serviceId, _name, grainTypeName, grainId, expectedVersion, currentVersion);
+
             var grainIdString = grainId.ToString();
             var documents = new List<BsonDocument>();
 

--- a/framework/test/Aevatar.Core.Tests/TestGAgents/StateTrackingTestGAgent.cs
+++ b/framework/test/Aevatar.Core.Tests/TestGAgents/StateTrackingTestGAgent.cs
@@ -1,0 +1,73 @@
+using Aevatar.Core.Abstractions;
+
+namespace Aevatar.Core.Tests.TestGAgents;
+
+public interface IStateTrackingTestGAgent : IStateGAgent<StateTrackingTestGAgentState>
+{
+    Task UpdateTestDataAsync(string data);
+    Task<int> GetCurrentVersionAsync();
+}
+
+[GenerateSerializer]
+public class StateTrackingTestGAgentState : StateBase
+{
+    [Id(0)] public int HandleStateChangedCallCount { get; set; }
+    [Id(1)] public List<int> ProcessedVersions { get; set; } = [];
+    [Id(2)] public DateTime LastStateChangeTime { get; set; }
+    [Id(3)] public string TestData { get; set; } = string.Empty;
+}
+
+[GenerateSerializer]
+public class StateTrackingTestStateLogEvent : StateLogEventBase<StateTrackingTestStateLogEvent>
+{
+    [Id(0)] public Guid Id { get; set; }
+    [Id(1)] public string Data { get; set; } = string.Empty;
+}
+
+[GAgent("stateTrackingTest")]
+public class StateTrackingTestGAgent : GAgentBase<StateTrackingTestGAgentState, StateTrackingTestStateLogEvent>, IStateTrackingTestGAgent
+{
+    public override Task<string> GetDescriptionAsync()
+    {
+        return Task.FromResult("Test GAgent for tracking state changes and version filtering");
+    }
+
+    protected override async Task HandleStateChangedAsync()
+    {
+        await base.HandleStateChangedAsync();
+        
+        // Track the call
+        State.HandleStateChangedCallCount++;
+        State.ProcessedVersions.Add(Version);
+        State.LastStateChangeTime = DateTime.UtcNow;
+    }
+
+    // Method to trigger a state change for testing
+    public async Task UpdateTestDataAsync(string data)
+    {
+        var stateLogEvent = new StateTrackingTestStateLogEvent
+        {
+            Id = Guid.NewGuid(),
+            Data = data
+        };
+        
+        RaiseEvent(stateLogEvent);
+        await ConfirmEvents();
+    }
+
+    // Override GAgentTransitionState to handle the state change properly
+    protected override void GAgentTransitionState(StateTrackingTestGAgentState state, StateLogEventBase<StateTrackingTestStateLogEvent> @event)
+    {
+        if (@event is StateTrackingTestStateLogEvent stateLogEvent)
+        {
+            state.TestData = stateLogEvent.Data;
+        }
+        base.GAgentTransitionState(state, @event);
+    }
+
+    // Method to get current version for testing
+    public Task<int> GetCurrentVersionAsync()
+    {
+        return Task.FromResult(Version);
+    }
+} 

--- a/station/samples/VerifyDbIssue545/Program.cs
+++ b/station/samples/VerifyDbIssue545/Program.cs
@@ -15,7 +15,7 @@ using VerifyDbIssue545;
 using Aevatar.Core.Streaming.Extensions;
 
 // Parse command line arguments
-bool useStoredIds = false;
+bool useStoredIds = true; // Default to using stored IDs
 int subscriberCount = 1; // Default value
 
 // Display usage information


### PR DESCRIPTION
- Filter view change during activation and Ignore duplicated state change notification from Orleans
- Minor changes in logs and E2E test