### PR TITLE
[Fix]silo runtime error caused by missing json file

### DIFF
--- a/station/src/Aevatar.Silo/Aevatar.Silo.csproj
+++ b/station/src/Aevatar.Silo/Aevatar.Silo.csproj
@@ -49,6 +49,9 @@
         <None Update="appsettings.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="appsettings.business.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Silo start up throw exception complaining "appsetting.business.json" could not be found