### PR TITLE
Migrate PR 92: Add SpeechGAgent for TTS & STT

### DIFF
--- a/gagents/samples/SpeechGAgent.Grains/SpeechGAgent.Grains.csproj
+++ b/gagents/samples/SpeechGAgent.Grains/SpeechGAgent.Grains.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Aevatar.Core.Abstractions"/>
+        <PackageReference Include="Aevatar.Core"/>
+        <PackageReference Include="Aevatar.EventSourcing.Core"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Aevatar.GAgents.Speech\Aevatar.GAgents.Speech.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/gagents/samples/SpeechGAgent.Host/Program.cs
+++ b/gagents/samples/SpeechGAgent.Host/Program.cs
@@ -1,0 +1,66 @@
+﻿using Aevatar.Core;
+using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.Speech.GAgent;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options => { });
+builder.Services.AddCors();
+builder.Services.AddTransient<IGAgentFactory, GAgentFactory>();
+builder.Services.AddHttpClient();
+
+builder.Services.AddAntiforgery(options => options.SuppressXFrameOptionsHeader = true);
+
+builder.Services.AddDirectoryBrowser();
+
+builder.Host.UseOrleansClient(client =>
+{
+    client.UseLocalhostClustering();
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(options => { });
+}
+
+app.UseCors(corsPolicyBuilder => corsPolicyBuilder
+    .AllowAnyOrigin()
+    .AllowAnyMethod()
+    .AllowAnyHeader());
+
+app.UseStaticFiles();
+app.UseDefaultFiles();
+
+var gAgentFactory = app.Services.GetRequiredService<IGAgentFactory>();
+
+app.MapPost("/api/speech-to-text", async (IFormFile file) =>
+{
+    if (file.Length == 0)
+        return Results.BadRequest("No file uploaded");
+
+    using var memoryStream = new MemoryStream();
+    await file.CopyToAsync(memoryStream);
+    var audioData = memoryStream.ToArray();
+
+    var speechGAgent = await gAgentFactory.GetGAgentAsync<ISpeechGAgent>(new SpeechGAgentConfiguration());
+    var text = await speechGAgent.SpeechToTextAsync(audioData);
+
+    return Results.Ok(new { text });
+}).DisableAntiforgery();
+
+app.MapPost("/api/text-to-speech", async ([FromBody] string text) =>
+{
+    var speechGAgent = await gAgentFactory.GetGAgentAsync<ISpeechGAgent>(new SpeechGAgentConfiguration());
+    var audioData = await speechGAgent.TextToSpeechAsync(text);
+
+    return Results.File(audioData, "audio/wav");
+}).DisableAntiforgery();
+
+app.MapFallbackToFile("index.html");
+
+app.Run();

--- a/gagents/samples/SpeechGAgent.Host/SpeechGAgent.Host.csproj
+++ b/gagents/samples/SpeechGAgent.Host/SpeechGAgent.Host.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>SpeechGAgent.Host</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.Orleans.Client" />
+        <PackageReference Include="Microsoft.CognitiveServices.Speech" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SpeechGAgent.Grains\SpeechGAgent.Grains.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/gagents/samples/SpeechGAgent.Host/wwwroot/index.html
+++ b/gagents/samples/SpeechGAgent.Host/wwwroot/index.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>语音助手</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .section {
+            border: 1px solid #ccc;
+            padding: 20px;
+            border-radius: 5px;
+        }
+        button {
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        button:disabled {
+            background-color: #ccc;
+            cursor: not-allowed;
+        }
+        #audioPlayer {
+            width: 100%;
+            margin-top: 10px;
+        }
+        .recording-indicator {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            background-color: red;
+            border-radius: 50%;
+            margin-right: 5px;
+            animation: blink 1s infinite;
+        }
+        @keyframes blink {
+            50% { opacity: 0; }
+        }
+        .recording-controls {
+            display: flex;
+            align-items: center;
+            margin-top: 10px;
+        }
+        .recording-result-item {
+            margin-bottom: 10px;
+            padding: 10px;
+            border: 1px solid #eee;
+            border-radius: 5px;
+        }
+        .recording-result-item .time {
+            color: #666;
+            font-size: 0.9em;
+        }
+        .recording-result-item .text {
+            margin: 5px 0;
+        }
+        .recording-result-item .actions {
+            display: flex;
+            gap: 10px;
+        }
+        .recording-result-item .actions button {
+            padding: 5px 10px;
+            font-size: 0.9em;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="section">
+            <h2>实时语音转文字</h2>
+            <div class="recording-controls">
+                <button id="startRecording" onclick="startRecording()">开始录音</button>
+                <button id="stopRecording" onclick="stopRecording()" disabled>停止录音</button>
+                <div id="recordingStatus" style="display: none;">
+                    <span class="recording-indicator"></span>
+                    <span>正在录音...</span>
+                </div>
+            </div>
+            <div id="recordingResult" style="margin-top: 20px;"></div>
+        </div>
+
+        <div class="section">
+            <h2>上传音频文件转文字</h2>
+            <input type="file" id="audioFile" accept=".wav" />
+            <button onclick="speechToText()">转换</button>
+            <div id="textResult"></div>
+        </div>
+
+        <div class="section">
+            <h2>文字转语音</h2>
+            <textarea id="textInput" rows="4" style="width: 100%"></textarea>
+            <button onclick="textToSpeech()">转换</button>
+            <audio id="audioPlayer" controls></audio>
+        </div>
+    </div>
+
+    <script>
+        let mediaRecorder;
+        let audioChunks = [];
+        let isRecording = false;
+        let lastRecordingBlob = null;
+
+        async function startRecording() {
+            try {
+                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                mediaRecorder = new MediaRecorder(stream);
+                audioChunks = [];
+
+                mediaRecorder.ondataavailable = (event) => {
+                    audioChunks.push(event.data);
+                };
+
+                mediaRecorder.onstop = async () => {
+                    lastRecordingBlob = new Blob(audioChunks, { type: 'audio/wav' });
+                    await processAudioBlob(lastRecordingBlob);
+                };
+
+                mediaRecorder.start(1000); // 每秒收集一次数据
+                isRecording = true;
+                document.getElementById('startRecording').disabled = true;
+                document.getElementById('stopRecording').disabled = false;
+                document.getElementById('recordingStatus').style.display = 'block';
+            } catch (error) {
+                console.error('Error accessing microphone:', error);
+                alert('无法访问麦克风，请确保已授予权限');
+            }
+        }
+
+        function stopRecording() {
+            if (mediaRecorder && isRecording) {
+                mediaRecorder.stop();
+                mediaRecorder.stream.getTracks().forEach(track => track.stop());
+                isRecording = false;
+                document.getElementById('startRecording').disabled = false;
+                document.getElementById('stopRecording').disabled = true;
+                document.getElementById('recordingStatus').style.display = 'none';
+            }
+        }
+
+        function playLastRecording() {
+            if (lastRecordingBlob) {
+                const audioUrl = URL.createObjectURL(lastRecordingBlob);
+                const audio = new Audio(audioUrl);
+                audio.play();
+            } else {
+                alert('没有可播放的录音');
+            }
+        }
+
+        async function processAudioBlob(audioBlob) {
+            const formData = new FormData();
+            formData.append('file', audioBlob, 'recording.wav');
+
+            try {
+                const response = await fetch('/api/speech-to-text', {
+                    method: 'POST',
+                    body: formData
+                });
+                const result = await response.json();
+                const resultDiv = document.getElementById('recordingResult');
+                const time = new Date().toLocaleTimeString();
+                
+                const resultItem = document.createElement('div');
+                resultItem.className = 'recording-result-item';
+                resultItem.innerHTML = `
+                    <div class="time">${time}</div>
+                    <div class="text">${result.text}</div>
+                    <div class="actions">
+                        <button onclick="playLastRecording()">播放录音</button>
+                    </div>
+                `;
+                
+                resultDiv.insertBefore(resultItem, resultDiv.firstChild);
+            } catch (error) {
+                console.error('Error:', error);
+                alert('转换失败');
+            }
+        }
+
+        async function speechToText() {
+            const fileInput = document.getElementById('audioFile');
+            const file = fileInput.files[0];
+            if (!file) {
+                alert('请选择音频文件');
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            try {
+                const response = await fetch('/api/speech-to-text', {
+                    method: 'POST',
+                    body: formData
+                });
+                const result = await response.json();
+                document.getElementById('textResult').textContent = result.text;
+            } catch (error) {
+                console.error('Error:', error);
+                alert('转换失败');
+            }
+        }
+
+        async function textToSpeech() {
+            const text = document.getElementById('textInput').value;
+            if (!text) {
+                alert('请输入文字');
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/text-to-speech', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(text)
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                
+                const blob = await response.blob();
+                const audioUrl = URL.createObjectURL(blob);
+                const audioPlayer = document.getElementById('audioPlayer');
+                audioPlayer.src = audioUrl;
+                audioPlayer.play();
+            } catch (error) {
+                console.error('Error:', error);
+                alert('转换失败');
+            }
+        }
+    </script>
+</body>
+</html>

--- a/gagents/samples/SpeechGAgent.Silo/Program.cs
+++ b/gagents/samples/SpeechGAgent.Silo/Program.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.Speech;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = Host.CreateDefaultBuilder(args)
+    .UseOrleans(silo =>
+    {
+        silo.AddMemoryGrainStorage("Default")
+            .AddMemoryStreams(AevatarCoreConstants.StreamProvider)
+            .AddMemoryGrainStorage("PubSubStore")
+            .AddLogStorageBasedLogConsistencyProvider("LogStorage")
+            .UseLocalhostClustering()
+            .ConfigureLogging(logging => logging.AddConsole());
+    })
+    .ConfigureServices((context, services) =>
+    {
+        services.Configure<SpeechOptions>(context.Configuration.GetSection("Speech"));
+    })
+    .UseConsoleLifetime();
+
+using var host = builder.Build();
+
+await host.RunAsync();

--- a/gagents/samples/SpeechGAgent.Silo/SpeechGAgent.Silo.csproj
+++ b/gagents/samples/SpeechGAgent.Silo/SpeechGAgent.Silo.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Server"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting"/>
+        <PackageReference Include="Aevatar.Core.Abstractions"/>
+        <PackageReference Include="Aevatar.Core"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Aevatar.GAgents.Basic\Aevatar.GAgents.Basic.csproj" />
+        <ProjectReference Include="..\..\..\src\Aevatar.GAgents.Speech\Aevatar.GAgents.Speech.csproj" />
+        <ProjectReference Include="..\SpeechGAgent.Grains\SpeechGAgent.Grains.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/gagents/samples/SpeechGAgent.Silo/appsettings.json
+++ b/gagents/samples/SpeechGAgent.Silo/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "Speech": {
+    "SubscriptionKey": "",
+    "Region": "",
+    "RecognitionLanguage": "zh-CN",
+    "SynthesisLanguage": "zh-CN",
+    "SynthesisVoiceName": "zh-CN-XiaoxiaoNeural"
+  }
+}

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Grains/SpeechGAgent.Grains.csproj
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Grains/SpeechGAgent.Grains.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Aevatar.Core.Abstractions"/>
+        <PackageReference Include="Aevatar.Core"/>
+        <PackageReference Include="Aevatar.EventSourcing.Core"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Aevatar.GAgents.Speech\Aevatar.GAgents.Speech.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Host/Program.cs
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Host/Program.cs
@@ -1,0 +1,66 @@
+﻿using Aevatar.Core;
+using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.Speech.GAgent;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options => { });
+builder.Services.AddCors();
+builder.Services.AddTransient<IGAgentFactory, GAgentFactory>();
+builder.Services.AddHttpClient();
+
+builder.Services.AddAntiforgery(options => options.SuppressXFrameOptionsHeader = true);
+
+builder.Services.AddDirectoryBrowser();
+
+builder.Host.UseOrleansClient(client =>
+{
+    client.UseLocalhostClustering();
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(options => { });
+}
+
+app.UseCors(corsPolicyBuilder => corsPolicyBuilder
+    .AllowAnyOrigin()
+    .AllowAnyMethod()
+    .AllowAnyHeader());
+
+app.UseStaticFiles();
+app.UseDefaultFiles();
+
+var gAgentFactory = app.Services.GetRequiredService<IGAgentFactory>();
+
+app.MapPost("/api/speech-to-text", async (IFormFile file) =>
+{
+    if (file.Length == 0)
+        return Results.BadRequest("No file uploaded");
+
+    using var memoryStream = new MemoryStream();
+    await file.CopyToAsync(memoryStream);
+    var audioData = memoryStream.ToArray();
+
+    var speechGAgent = await gAgentFactory.GetGAgentAsync<ISpeechGAgent>(new SpeechGAgentConfiguration());
+    var text = await speechGAgent.SpeechToTextAsync(audioData);
+
+    return Results.Ok(new { text });
+}).DisableAntiforgery();
+
+app.MapPost("/api/text-to-speech", async ([FromBody] string text) =>
+{
+    var speechGAgent = await gAgentFactory.GetGAgentAsync<ISpeechGAgent>(new SpeechGAgentConfiguration());
+    var audioData = await speechGAgent.TextToSpeechAsync(text);
+
+    return Results.File(audioData, "audio/wav");
+}).DisableAntiforgery();
+
+app.MapFallbackToFile("index.html");
+
+app.Run();

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Host/SpeechGAgent.Host.csproj
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Host/SpeechGAgent.Host.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>SpeechGAgent.Host</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.Orleans.Client" />
+        <PackageReference Include="Microsoft.CognitiveServices.Speech" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SpeechGAgent.Grains\SpeechGAgent.Grains.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Host/wwwroot/index.html
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Host/wwwroot/index.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>语音助手</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .section {
+            border: 1px solid #ccc;
+            padding: 20px;
+            border-radius: 5px;
+        }
+        button {
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        button:disabled {
+            background-color: #ccc;
+            cursor: not-allowed;
+        }
+        #audioPlayer {
+            width: 100%;
+            margin-top: 10px;
+        }
+        .recording-indicator {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            background-color: red;
+            border-radius: 50%;
+            margin-right: 5px;
+            animation: blink 1s infinite;
+        }
+        @keyframes blink {
+            50% { opacity: 0; }
+        }
+        .recording-controls {
+            display: flex;
+            align-items: center;
+            margin-top: 10px;
+        }
+        .recording-result-item {
+            margin-bottom: 10px;
+            padding: 10px;
+            border: 1px solid #eee;
+            border-radius: 5px;
+        }
+        .recording-result-item .time {
+            color: #666;
+            font-size: 0.9em;
+        }
+        .recording-result-item .text {
+            margin: 5px 0;
+        }
+        .recording-result-item .actions {
+            display: flex;
+            gap: 10px;
+        }
+        .recording-result-item .actions button {
+            padding: 5px 10px;
+            font-size: 0.9em;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="section">
+            <h2>实时语音转文字</h2>
+            <div class="recording-controls">
+                <button id="startRecording" onclick="startRecording()">开始录音</button>
+                <button id="stopRecording" onclick="stopRecording()" disabled>停止录音</button>
+                <div id="recordingStatus" style="display: none;">
+                    <span class="recording-indicator"></span>
+                    <span>正在录音...</span>
+                </div>
+            </div>
+            <div id="recordingResult" style="margin-top: 20px;"></div>
+        </div>
+
+        <div class="section">
+            <h2>上传音频文件转文字</h2>
+            <input type="file" id="audioFile" accept=".wav" />
+            <button onclick="speechToText()">转换</button>
+            <div id="textResult"></div>
+        </div>
+
+        <div class="section">
+            <h2>文字转语音</h2>
+            <textarea id="textInput" rows="4" style="width: 100%"></textarea>
+            <button onclick="textToSpeech()">转换</button>
+            <audio id="audioPlayer" controls></audio>
+        </div>
+    </div>
+
+    <script>
+        let mediaRecorder;
+        let audioChunks = [];
+        let isRecording = false;
+        let lastRecordingBlob = null;
+
+        async function startRecording() {
+            try {
+                const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                mediaRecorder = new MediaRecorder(stream);
+                audioChunks = [];
+
+                mediaRecorder.ondataavailable = (event) => {
+                    audioChunks.push(event.data);
+                };
+
+                mediaRecorder.onstop = async () => {
+                    lastRecordingBlob = new Blob(audioChunks, { type: 'audio/wav' });
+                    await processAudioBlob(lastRecordingBlob);
+                };
+
+                mediaRecorder.start(1000); // 每秒收集一次数据
+                isRecording = true;
+                document.getElementById('startRecording').disabled = true;
+                document.getElementById('stopRecording').disabled = false;
+                document.getElementById('recordingStatus').style.display = 'block';
+            } catch (error) {
+                console.error('Error accessing microphone:', error);
+                alert('无法访问麦克风，请确保已授予权限');
+            }
+        }
+
+        function stopRecording() {
+            if (mediaRecorder && isRecording) {
+                mediaRecorder.stop();
+                mediaRecorder.stream.getTracks().forEach(track => track.stop());
+                isRecording = false;
+                document.getElementById('startRecording').disabled = false;
+                document.getElementById('stopRecording').disabled = true;
+                document.getElementById('recordingStatus').style.display = 'none';
+            }
+        }
+
+        function playLastRecording() {
+            if (lastRecordingBlob) {
+                const audioUrl = URL.createObjectURL(lastRecordingBlob);
+                const audio = new Audio(audioUrl);
+                audio.play();
+            } else {
+                alert('没有可播放的录音');
+            }
+        }
+
+        async function processAudioBlob(audioBlob) {
+            const formData = new FormData();
+            formData.append('file', audioBlob, 'recording.wav');
+
+            try {
+                const response = await fetch('/api/speech-to-text', {
+                    method: 'POST',
+                    body: formData
+                });
+                const result = await response.json();
+                const resultDiv = document.getElementById('recordingResult');
+                const time = new Date().toLocaleTimeString();
+                
+                const resultItem = document.createElement('div');
+                resultItem.className = 'recording-result-item';
+                resultItem.innerHTML = `
+                    <div class="time">${time}</div>
+                    <div class="text">${result.text}</div>
+                    <div class="actions">
+                        <button onclick="playLastRecording()">播放录音</button>
+                    </div>
+                `;
+                
+                resultDiv.insertBefore(resultItem, resultDiv.firstChild);
+            } catch (error) {
+                console.error('Error:', error);
+                alert('转换失败');
+            }
+        }
+
+        async function speechToText() {
+            const fileInput = document.getElementById('audioFile');
+            const file = fileInput.files[0];
+            if (!file) {
+                alert('请选择音频文件');
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            try {
+                const response = await fetch('/api/speech-to-text', {
+                    method: 'POST',
+                    body: formData
+                });
+                const result = await response.json();
+                document.getElementById('textResult').textContent = result.text;
+            } catch (error) {
+                console.error('Error:', error);
+                alert('转换失败');
+            }
+        }
+
+        async function textToSpeech() {
+            const text = document.getElementById('textInput').value;
+            if (!text) {
+                alert('请输入文字');
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/text-to-speech', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(text)
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                
+                const blob = await response.blob();
+                const audioUrl = URL.createObjectURL(blob);
+                const audioPlayer = document.getElementById('audioPlayer');
+                audioPlayer.src = audioUrl;
+                audioPlayer.play();
+            } catch (error) {
+                console.error('Error:', error);
+                alert('转换失败');
+            }
+        }
+    </script>
+</body>
+</html>

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Silo/Program.cs
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Silo/Program.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.Speech;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = Host.CreateDefaultBuilder(args)
+    .UseOrleans(silo =>
+    {
+        silo.AddMemoryGrainStorage("Default")
+            .AddMemoryStreams(AevatarCoreConstants.StreamProvider)
+            .AddMemoryGrainStorage("PubSubStore")
+            .AddLogStorageBasedLogConsistencyProvider("LogStorage")
+            .UseLocalhostClustering()
+            .ConfigureLogging(logging => logging.AddConsole());
+    })
+    .ConfigureServices((context, services) =>
+    {
+        services.Configure<SpeechOptions>(context.Configuration.GetSection("Speech"));
+    })
+    .UseConsoleLifetime();
+
+using var host = builder.Build();
+
+await host.RunAsync();

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Silo/SpeechGAgent.Silo.csproj
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Silo/SpeechGAgent.Silo.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Server"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting"/>
+        <PackageReference Include="Aevatar.Core.Abstractions"/>
+        <PackageReference Include="Aevatar.Core"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Aevatar.GAgents.Basic\Aevatar.GAgents.Basic.csproj" />
+        <ProjectReference Include="..\..\..\src\Aevatar.GAgents.Speech\Aevatar.GAgents.Speech.csproj" />
+        <ProjectReference Include="..\SpeechGAgent.Grains\SpeechGAgent.Grains.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/gagents/samples/SpeechGAgent/SpeechGAgent.Silo/appsettings.json
+++ b/gagents/samples/SpeechGAgent/SpeechGAgent.Silo/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "Speech": {
+    "SubscriptionKey": "",
+    "Region": "",
+    "RecognitionLanguage": "zh-CN",
+    "SynthesisLanguage": "zh-CN",
+    "SynthesisVoiceName": "zh-CN-XiaoxiaoNeural"
+  }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/Aevatar.GAgents.Speech.csproj
+++ b/gagents/src/Aevatar.GAgents.Speech/Aevatar.GAgents.Speech.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+        <Nullable>enable</Nullable>
+        <RootNamespace>Aevatar.GAgents.Speech</RootNamespace>
+        <NoWarn>$(NoWarn);SKEXP0001;SKEXP0010;SKEXP0020;SKEXP0070</NoWarn>
+        <PackageId>Aevatar.GAgents.Speech</PackageId>
+        <PackageType>Dependency</PackageType>
+        <Title>aevatar GAgents</Title>
+        <Authors>AElf</Authors>
+        <PackageTags>agent</PackageTags>
+        <RepositoryUrl>https://github.com/aevatarAI/aevatar-gagents</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageProjectUrl>https://github.com/aevatarAI/aevatar-gagents</PackageProjectUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CognitiveServices.Speech" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Aevatar.GAgents.Basic\Aevatar.GAgents.Basic.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/gagents/src/Aevatar.GAgents.Speech/AevatarGAgentsSpeechModule.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/AevatarGAgentsSpeechModule.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Modularity;
+
+namespace Aevatar.GAgents.Speech;
+
+public class AevatarGAgentsSpeechModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        var configuration = context.Services.GetConfiguration();
+        Configure<SpeechOptions>(configuration.GetSection("Speech")); 
+    }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/Events/RequestSTTEvent.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/Events/RequestSTTEvent.cs
@@ -1,0 +1,10 @@
+using Aevatar.Core.Abstractions;
+using Orleans;
+
+namespace Aevatar.GAgents.Speech.Events;
+
+[GenerateSerializer]
+public class RequestSTTEvent : EventBase
+{
+    [Id(0)] public byte[] AudioData { get; set; }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/Events/RequestTTSEvent.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/Events/RequestTTSEvent.cs
@@ -1,0 +1,10 @@
+using Aevatar.Core.Abstractions;
+using Orleans;
+
+namespace Aevatar.GAgents.Speech.Events;
+
+[GenerateSerializer]
+public class RequestTTSEvent : EventBase
+{
+    [Id(0)] public string Text { get; set; }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/Events/ResponseSTTEvent.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/Events/ResponseSTTEvent.cs
@@ -1,0 +1,10 @@
+using Aevatar.Core.Abstractions;
+using Orleans;
+
+namespace Aevatar.GAgents.Speech.Events;
+
+[GenerateSerializer]
+public class ResponseSTTEvent : EventBase
+{
+    [Id(0)] public string Text { get; set; }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/Events/ResponseTTSEvent.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/Events/ResponseTTSEvent.cs
@@ -1,0 +1,10 @@
+using Aevatar.Core.Abstractions;
+using Orleans;
+
+namespace Aevatar.GAgents.Speech.Events;
+
+[GenerateSerializer]
+public class ResponseTTSEvent : EventBase
+{
+    [Id(0)] public byte[] AudioData { get; set; }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/GAgent/ISpeechGAgent.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/GAgent/ISpeechGAgent.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Aevatar.Core.Abstractions;
+
+namespace Aevatar.GAgents.Speech.GAgent;
+
+public interface ISpeechGAgent : IStateGAgent<SpeechGAgentState>
+{
+    Task<string> SpeechToTextAsync(byte[] audioData);
+    Task<byte[]> TextToSpeechAsync(string text);
+}

--- a/gagents/src/Aevatar.GAgents.Speech/GAgent/SpeechGAgent.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/GAgent/SpeechGAgent.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Aevatar.Core;
+using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.Speech.Events;
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans;
+
+namespace Aevatar.GAgents.Speech.GAgent;
+
+[GenerateSerializer]
+public class SpeechGAgentState : StateBase
+{
+    [Id(0)] public string SubscriptionKey { get; set; }
+    [Id(1)] public string Region { get; set; }
+    [Id(2)] public string RecognitionLanguage { get; set; }
+    [Id(3)] public string SynthesisLanguage { get; set; }
+    [Id(4)] public string SynthesisVoiceName { get; set; }
+}
+
+[GenerateSerializer]
+public class SpeechStateLogEvent : StateLogEventBase<SpeechStateLogEvent>
+{
+
+}
+
+[GenerateSerializer]
+public class SpeechGAgentConfiguration : ConfigurationBase
+{
+    [Id(0)] public string? SubscriptionKey { get; set; }
+    [Id(1)] public string? Region { get; set; }
+    [Id(2)] public string? RecognitionLanguage { get; set; }
+    [Id(3)] public string? SynthesisLanguage { get; set; }
+    [Id(4)] public string? SynthesisVoiceName { get; set; }
+}
+
+[GAgent]
+public class SpeechGAgent : GAgentBase<SpeechGAgentState, SpeechStateLogEvent, EventBase, SpeechGAgentConfiguration>,
+    ISpeechGAgent
+{
+    private SpeechConfig _speechConfig;
+    private SpeechSynthesizer _synthesizer;
+    private readonly SpeechOptions _speechOptions;
+
+    public SpeechGAgent(IOptionsSnapshot<SpeechOptions> speechOptions)
+    {
+        _speechOptions = speechOptions.Value;
+    }
+
+    public override Task<string> GetDescriptionAsync()
+    {
+        return Task.FromResult("This is a GAgent for TTS & STT.");
+    }
+
+    protected override async Task PerformConfigAsync(SpeechGAgentConfiguration configuration)
+    {
+        RaiseEvent(new ConfigSpeechStateLogEvent
+        {
+            SubscriptionKey = configuration.SubscriptionKey ?? _speechOptions.SubscriptionKey,
+            Region = configuration.Region ?? _speechOptions.Region,
+            RecognitionLanguage = configuration.RecognitionLanguage ?? _speechOptions.RecognitionLanguage,
+            SynthesisLanguage = configuration.SynthesisLanguage ?? _speechOptions.SynthesisLanguage,
+            SynthesisVoiceName = configuration.SynthesisVoiceName ?? _speechOptions.SynthesisVoiceName
+        });
+        await ConfirmEvents();
+        await base.PerformConfigAsync(configuration);
+    }
+
+    [EventHandler]
+    public async Task HandleEventAsync(RequestSTTEvent eventData)
+    {
+        var text = await SpeechToTextAsync(eventData.AudioData);
+        await PublishAsync(new ResponseSTTEvent
+        {
+            Text = text
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleEventAsync(RequestTTSEvent eventData)
+    {
+        var audioData = await TextToSpeechAsync(eventData.Text);
+        await PublishAsync(new ResponseTTSEvent
+        {
+            AudioData = audioData
+        });
+    }
+
+    private bool EnsureConfiguration()
+    {
+        if (State.SubscriptionKey.IsNullOrEmpty())
+        {
+            Logger.LogError("[{grainId}] Not configured.", this.GetGrainId().ToString());
+            return false;
+        }
+
+        _speechConfig = SpeechConfig.FromSubscription(State.SubscriptionKey, State.Region);
+        _speechConfig.SpeechRecognitionLanguage = State.RecognitionLanguage;
+        _speechConfig.SpeechSynthesisLanguage = State.SynthesisLanguage;
+        _speechConfig.SpeechSynthesisVoiceName = State.SynthesisVoiceName;
+        _synthesizer = new SpeechSynthesizer(_speechConfig);
+
+        return true;
+    }
+
+    protected override void GAgentTransitionState(SpeechGAgentState state,
+        StateLogEventBase<SpeechStateLogEvent> @event)
+    {
+        switch (@event)
+        {
+            case ConfigSpeechStateLogEvent configSpeechStateLogEvent:
+                State.SubscriptionKey = configSpeechStateLogEvent.SubscriptionKey;
+                State.Region = configSpeechStateLogEvent.Region;
+                State.RecognitionLanguage = configSpeechStateLogEvent.RecognitionLanguage;
+                State.SynthesisLanguage = configSpeechStateLogEvent.SynthesisLanguage;
+                State.SynthesisVoiceName = configSpeechStateLogEvent.SynthesisVoiceName;
+                break;
+        }
+    }
+
+    [GenerateSerializer]
+    public class ConfigSpeechStateLogEvent : StateLogEventBase<SpeechStateLogEvent>
+    {
+        [Id(0)] public required string SubscriptionKey { get; set; }
+        [Id(1)] public required string Region { get; set; }
+        [Id(2)] public required string RecognitionLanguage { get; set; }
+        [Id(3)] public required string SynthesisLanguage { get; set; }
+        [Id(4)] public required string SynthesisVoiceName { get; set; }
+    }
+
+    public async Task<string> SpeechToTextAsync(byte[] audioData)
+    {
+        if (!EnsureConfiguration()) return string.Empty;
+
+        var tempFilePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllBytesAsync(tempFilePath, audioData);
+
+            using var audioConfig = AudioConfig.FromWavFileInput(tempFilePath);
+            using var recognizer = new SpeechRecognizer(_speechConfig, audioConfig);
+
+            var result = await recognizer.RecognizeOnceAsync();
+            return result.Text;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error during speech recognition.");
+            return string.Empty;
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+    }
+
+    public async Task<byte[]> TextToSpeechAsync(string text)
+    {
+        if (!EnsureConfiguration()) return [];
+
+        using var result = await _synthesizer.SpeakTextAsync(text);
+        return result.AudioData;
+    }
+}

--- a/gagents/src/Aevatar.GAgents.Speech/ISpeechService.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/ISpeechService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Aevatar.GAgents.Speech;
+
+public interface ISpeechService
+{
+    Task<string> SpeechToTextAsync(byte[] audioData);
+    Task<byte[]> TextToSpeechAsync(string text);
+}

--- a/gagents/src/Aevatar.GAgents.Speech/SpeechOptions.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/SpeechOptions.cs
@@ -1,0 +1,10 @@
+namespace Aevatar.GAgents.Speech;
+
+public class SpeechOptions
+{
+    public string SubscriptionKey { get; set; }
+    public string Region { get; set; }
+    public string RecognitionLanguage { get; set; } = "zh-CN";
+    public string SynthesisLanguage { get; set; } = "zh-CN";
+    public string SynthesisVoiceName { get; set; } = "zh-CN-XiaoxiaoNeural";
+}

--- a/gagents/src/Aevatar.GAgents.Speech/SpeechService.cs
+++ b/gagents/src/Aevatar.GAgents.Speech/SpeechService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.GAgents.Speech;
+
+public class SpeechService : ISpeechService
+{
+    private readonly SpeechConfig _speechConfig;
+    private readonly SpeechSynthesizer _synthesizer;
+
+    public SpeechService(IOptionsSnapshot<SpeechOptions> speechOptions)
+    {
+        _speechConfig = SpeechConfig.FromSubscription(speechOptions.Value.SubscriptionKey, speechOptions.Value.Region);
+        _speechConfig.SpeechRecognitionLanguage = "zh-CN";
+        _speechConfig.SpeechSynthesisLanguage = "zh-CN";
+        _speechConfig.SpeechSynthesisVoiceName = "zh-CN-XiaoxiaoNeural";
+        _synthesizer = new SpeechSynthesizer(_speechConfig);
+    }
+
+    public async Task<string> SpeechToTextAsync(byte[] audioData)
+    {
+        var tempFilePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllBytesAsync(tempFilePath, audioData);
+
+            using var audioConfig = AudioConfig.FromWavFileInput(tempFilePath);
+            using var recognizer = new SpeechRecognizer(_speechConfig, audioConfig);
+
+            var result = await recognizer.RecognizeOnceAsync();
+            return result.Text;
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+    }
+
+    public async Task<byte[]> TextToSpeechAsync(string text)
+    {
+        using var result = await _synthesizer.SpeakTextAsync(text);
+        return result.AudioData;
+    }
+}


### PR DESCRIPTION
Migrated from aevatarAI/aevatar-gagents PR 92
- Add comprehensive speech functionality with TTS (Text-to-Speech) and STT (Speech-to-Text)
- SpeechGAgent with event-driven architecture for speech requests/responses
- SpeechService implementation with configurable options
- Complete sample application with Host, Silo, and web interface
- HTML interface for testing speech functionality

Core Components:
- src/Aevatar.GAgents.Speech/ - Main speech module with events, services, and GAgent
- samples/SpeechGAgent/ - Complete working sample application
- Event-based communication: RequestTTS/ResponseTTS, RequestSTT/ResponseSTT

Created by: eanzhao
19 files added focused on speech functionality only