### PR TITLE
Migrate PR #164: feat: check cycle error

### DIFF
--- a/gagents/src/Aevatar.GAgents.GroupChat/GAgent/Coordinator/WorkflowView/WorkflowViewGAgent.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat/GAgent/Coordinator/WorkflowView/WorkflowViewGAgent.cs
@@ -64,6 +64,13 @@ public class WorkflowViewGAgent : GAgentBase<WorkflowViewState, WorkflowViewLogE
             throw new ArgumentException("The workflow view invalid nodeId.");
         }
 
+        // Detect cycle in edges before proceeding
+        if (HasCycle(nodeIdList, configuration.WorkflowNodeUnitList))
+        {
+            Logger.LogError("[WorkflowViewGAgent] The workflow view contains a cycle.");
+            throw new ArgumentException("The workflow view contains a cycle.");
+        }
+
         var addNodeList = new List<WorkflowNodeDto>();
         var updateNodeList = new List<WorkflowNodeDto>();
         foreach (var node in configuration.WorkflowNodeList)
@@ -98,6 +105,53 @@ public class WorkflowViewGAgent : GAgentBase<WorkflowViewState, WorkflowViewLogE
                 AgentId = configuration.WorkflowCoordinatorGAgentId
             });
         }
+    }
+
+    private static bool HasCycle(IReadOnlyCollection<Guid> nodeIds, IEnumerable<WorkflowNodeUnitDto> units)
+    {
+        // Build adjacency and in-degree maps
+        var adjacency = new Dictionary<Guid, List<Guid>>();
+        var inDegree = new Dictionary<Guid, int>();
+        foreach (var id in nodeIds)
+        {
+            adjacency[id] = new List<Guid>();
+            inDegree[id] = 0;
+        }
+
+        foreach (var unit in units)
+        {
+            // Self-loop is a cycle
+            if (unit.NodeId == unit.NextNodeId)
+            {
+                return true;
+            }
+            if (!adjacency.ContainsKey(unit.NodeId) || !inDegree.ContainsKey(unit.NextNodeId))
+            {
+                // Should not happen due to prior validation, but guard anyway
+                continue;
+            }
+            adjacency[unit.NodeId].Add(unit.NextNodeId);
+            inDegree[unit.NextNodeId] = inDegree[unit.NextNodeId] + 1;
+        }
+
+        // Kahn's algorithm for cycle detection
+        var queue = new Queue<Guid>(inDegree.Where(kv => kv.Value == 0).Select(kv => kv.Key));
+        var visitedCount = 0;
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            visitedCount++;
+            foreach (var next in adjacency[current])
+            {
+                inDegree[next] = inDegree[next] - 1;
+                if (inDegree[next] == 0)
+                {
+                    queue.Enqueue(next);
+                }
+            }
+        }
+
+        return visitedCount < nodeIds.Count;
     }
 
     protected override void GAgentTransitionState(WorkflowViewState state,

--- a/gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/WorkFlowViewTest.cs
+++ b/gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/WorkFlowViewTest.cs
@@ -147,4 +147,79 @@ public sealed class WorkFlowViewTest : AevatarGroupChatTestBase
         exception.Message.ShouldContain("already has a parent GAgent");
         
     }
+
+    [Fact]
+    public async Task WorkflowViewTest_Should_Throw_When_SelfLoopExists()
+    {
+        var workflowViewAgent = await _agentFactory.GetGAgentAsync<IWorkflowViewGAgent>(Guid.NewGuid());
+        var workflowViewConfig = new WorkflowViewConfigDto();
+        var fread = await _agentFactory.GetGAgentAsync<IWorkerGAgent>(Guid.NewGuid());
+        var nodeId = Guid.NewGuid();
+        workflowViewConfig.Name = "workflowView-selfloop";
+        workflowViewConfig.WorkflowNodeList.Add(new WorkflowNodeDto()
+        {
+            NodeId = nodeId,
+            AgentType = fread.GetGrainId().Type.ToString(),
+            JsonProperties = JsonConvert.SerializeObject(new Dictionary<string, object>()
+            {
+                {"MemberName","fread"}
+            }),
+            Name = "fread"
+        });
+        // self-loop
+        workflowViewConfig.WorkflowNodeUnitList.Add(new WorkflowNodeUnitDto()
+        {
+            NodeId = nodeId,
+            NextNodeId = nodeId
+        });
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await workflowViewAgent.ConfigAsync(workflowViewConfig));
+        exception.Message.ShouldContain("contains a cycle");
+    }
+
+    [Fact]
+    public async Task WorkflowViewTest_Should_Throw_When_CycleExists()
+    {
+        var workflowViewAgent = await _agentFactory.GetGAgentAsync<IWorkflowViewGAgent>(Guid.NewGuid());
+        var workflowViewConfig = new WorkflowViewConfigDto();
+        var fread = await _agentFactory.GetGAgentAsync<IWorkerGAgent>(Guid.NewGuid());
+        var moni = await _agentFactory.GetGAgentAsync<ILeaderGAgent>(Guid.NewGuid());
+        var nodeId1 = Guid.NewGuid();
+        var nodeId2 = Guid.NewGuid();
+        workflowViewConfig.Name = "workflowView-cycle";
+        workflowViewConfig.WorkflowNodeList.Add(new WorkflowNodeDto()
+        {
+            NodeId = nodeId1,
+            AgentType = fread.GetGrainId().Type.ToString(),
+            JsonProperties = JsonConvert.SerializeObject(new Dictionary<string, object>()
+            {
+                {"MemberName","fread"}
+            }),
+            Name = "fread"
+        });
+        workflowViewConfig.WorkflowNodeList.Add(new WorkflowNodeDto()
+        {
+            NodeId = nodeId2,
+            AgentType = moni.GetGrainId().Type.ToString(),
+            JsonProperties = JsonConvert.SerializeObject(new Dictionary<string, object>()
+            {
+                {"MemberName","moni"}
+            }),
+            Name = "moni"
+        });
+        // create a 2-node cycle: 1->2 and 2->1
+        workflowViewConfig.WorkflowNodeUnitList.Add(new WorkflowNodeUnitDto()
+        {
+            NodeId = nodeId1,
+            NextNodeId = nodeId2
+        });
+        workflowViewConfig.WorkflowNodeUnitList.Add(new WorkflowNodeUnitDto()
+        {
+            NodeId = nodeId2,
+            NextNodeId = nodeId1
+        });
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await workflowViewAgent.ConfigAsync(workflowViewConfig));
+        exception.Message.ShouldContain("contains a cycle");
+    }
 }


### PR DESCRIPTION
## Description

This PR migrates [aevatarAI/aevatar-gagents#164](https://github.com/aevatarAI/aevatar-gagents/pull/164) to the aevatar-station repository.

### Original PR Details
- **Author**: chao0kang (chao.kang@aelf.io)
- **Title**: feat: check cycle error
- **Branch**: feature/fix-workflow-view-cycle

### Changes Made
This PR adds cycle detection to the WorkflowViewGAgent to prevent circular dependencies in workflow graphs. The implementation includes:

1. **Cycle Detection Algorithm**: Implements Kahn's algorithm for topological sorting to detect cycles in the workflow graph
2. **Self-Loop Detection**: Explicitly checks for and rejects self-referencing nodes
3. **Error Handling**: Throws ArgumentException with clear error message when cycles are detected

### Files Modified
- `gagents/src/Aevatar.GAgents.GroupChat/GAgent/Coordinator/WorkflowView/WorkflowViewGAgent.cs` - Added HasCycle method and cycle validation in PerformConfigAsync
- `gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/WorkFlowViewTest.cs` - Added two unit tests to verify cycle detection works correctly

### Testing
- All existing tests pass ✅
- Added two new tests:
  - `WorkflowViewTest_Should_Throw_When_SelfLoopExists` - Tests self-loop detection
  - `WorkflowViewTest_Should_Throw_When_CycleExists` - Tests general cycle detection

### Migration Details
- Migrated using `git cherry-pick -X subtree=gagents f2c47e3c`
- All changes correctly placed in the `gagents/` subdirectory
- Build and tests completed successfully
