### PR TITLE
Migrate PR #163: Add GenericMetaAttribute and ChatAISystemLLMEnum

### DIFF
--- a/gagents/src/Aevatar.GAgents.Basic/Common/GenericMetaAttribute.cs
+++ b/gagents/src/Aevatar.GAgents.Basic/Common/GenericMetaAttribute.cs
@@ -1,0 +1,46 @@
+namespace Aevatar.GAgents.Basic;
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
+public class GenericMetaAttribute : Attribute
+{
+    public string? Category { get; set; }
+    public string Key { get; set; }
+    public object Value { get; set; }
+    public string[]? PathLevels { get; set; }
+
+    public GenericMetaAttribute(string key, object value)
+    {
+        Category = null;
+        Key = key;
+        Value = value;
+        PathLevels = null;
+    }
+
+    public GenericMetaAttribute(string category, string key, object value)
+    {
+        Category = category;
+        Key = key;
+        Value = value;
+        PathLevels = new[] { category };
+    }
+
+    public GenericMetaAttribute(params object[] pathAndValue)
+    {
+        if (pathAndValue.Length < 2) throw new ArgumentException("至少需要key和value两个参数");
+
+        Value = pathAndValue[pathAndValue.Length - 1];
+        Key = pathAndValue[pathAndValue.Length - 2].ToString()!;
+        if (pathAndValue.Length > 2)
+        {
+            PathLevels = pathAndValue.Take(pathAndValue.Length - 2)
+                .Select(p => p.ToString()!)
+                .ToArray();
+            Category = PathLevels[0]; // 保持兼容性
+        }
+        else
+        {
+            PathLevels = null;
+            Category = null;
+        }
+    }
+}

--- a/gagents/src/Aevatar.GAgents.Twitter/GAgents/ChatAIAgent/ChatAISystemLLMEnum.cs
+++ b/gagents/src/Aevatar.GAgents.Twitter/GAgents/ChatAIAgent/ChatAISystemLLMEnum.cs
@@ -1,0 +1,60 @@
+using Orleans;
+using System.ComponentModel;
+using Aevatar.GAgents.Basic;
+
+namespace Aevatar.GAgents.Twitter.GAgents.ChatAIAgent;
+
+
+
+[GenerateSerializer]
+public enum ChatAISystemLLMEnum
+{
+    [Description("OpenAI GPT models for text generation and completion")]
+    [GenericMeta(SystemLLMMetaKeys.Provider, "openai")]
+    [GenericMeta(SystemLLMMetaKeys.Type, "general-purpose llm")]
+    [GenericMeta(SystemLLMMetaKeys.Strengths, "creative writing, general reasoning, versatile, well-balanced performance")]
+    [GenericMeta(SystemLLMMetaKeys.BestFor, "general tasks, creative writing, conversational AI, content generation")]
+    [GenericMeta(SystemLLMMetaKeys.Speed, "fast and reliable")]
+    OpenAI = 0,
+    
+    [Description("DeepSeek's advanced language models optimized for reasoning")]
+    [GenericMeta(SystemLLMMetaKeys.Provider, "deepseek")]
+    [GenericMeta(SystemLLMMetaKeys.Type, "reasoning-optimized llm")]
+    [GenericMeta(SystemLLMMetaKeys.Strengths, "advanced reasoning, mathematical thinking, logical analysis, deep problem-solving")]
+    [GenericMeta(SystemLLMMetaKeys.BestFor, "complex reasoning, mathematical problems, analytical tasks, research assistance")]
+    [GenericMeta(SystemLLMMetaKeys.Speed, "moderate, optimized for accuracy over speed")]
+    DeepSeek = 1,
+    
+    [Description("Azure-hosted OpenAI models with enterprise security")]
+    [GenericMeta(SystemLLMMetaKeys.Provider, "azure_openai")]
+    [GenericMeta(SystemLLMMetaKeys.Type, "enterprise llm")]
+    [GenericMeta(SystemLLMMetaKeys.Strengths, "enterprise security, compliance, scalability, data privacy, regional deployment")]
+    [GenericMeta(SystemLLMMetaKeys.BestFor, "enterprise applications, production systems, secure environments, regulated industries")]
+    [GenericMeta(SystemLLMMetaKeys.Speed, "fast with enterprise-grade reliability")]
+    AzureOpenAI = 2,
+    
+    [Description("Azure OpenAI embedding models for semantic search")]
+    [GenericMeta(SystemLLMMetaKeys.Provider, "azure_openai")]
+    [GenericMeta(SystemLLMMetaKeys.Type, "embedding model")]
+    [GenericMeta(SystemLLMMetaKeys.Strengths, "semantic understanding, enterprise security, high-quality embeddings, data privacy")]
+    [GenericMeta(SystemLLMMetaKeys.BestFor, "semantic search, document similarity, enterprise RAG systems, secure vector operations")]
+    [GenericMeta(SystemLLMMetaKeys.Speed, "fast embedding generation with enterprise features")]
+    AzureOpenAIEmbeddings = 3,
+    
+    [Description("OpenAI embedding models for semantic understanding")]
+    [GenericMeta(SystemLLMMetaKeys.Provider, "openai")]
+    [GenericMeta(SystemLLMMetaKeys.Type, "embedding model")]
+    [GenericMeta(SystemLLMMetaKeys.Strengths, "semantic understanding, high-quality embeddings, versatile text representation")]
+    [GenericMeta(SystemLLMMetaKeys.BestFor, "semantic search, similarity tasks, RAG applications, content recommendation")]
+    [GenericMeta(SystemLLMMetaKeys.Speed, "fast embedding generation")]
+    OpenAIEmbeddings = 4
+}
+
+public static class SystemLLMMetaKeys
+{
+    public const string Provider = "provider";
+    public const string Type = "type";
+    public const string Strengths = "strengths";
+    public const string BestFor = "best_for";
+    public const string Speed = "speed";
+}


### PR DESCRIPTION
## Overview
Migrated from aevatarAI/aevatar-gagents#163

This PR selectively migrates the core components of the structured-llm-enum-system feature from the aevatar-gagents repository.

## What's Included
- **GenericMetaAttribute.cs**: A flexible attribute system for adding metadata to enums and other types
- **ChatAISystemLLMEnum.cs**: An enum with structured metadata describing different LLM providers (OpenAI, DeepSeek, Azure OpenAI, etc.)

## Migration Approach
Due to extensive conflicts (57 files) caused by widespread Description attribute additions in the original PR, we opted for a selective migration approach:
1. Extracted only the two new core files
2. Placed them in their appropriate locations within the gagents subtree
3. Verified successful compilation

## Files Added
- `gagents/src/Aevatar.GAgents.Basic/Common/GenericMetaAttribute.cs`
- `gagents/src/Aevatar.GAgents.Twitter/GAgents/ChatAIAgent/ChatAISystemLLMEnum.cs`

## Testing
✅ Build completed successfully with no errors

## Notes
The ConfigDto Description attributes from the original PR were not included in this migration to avoid conflicts. These can be added separately if needed.