### PR TITLE
Migrate PR #160: GroupChat workflow failure handling (Correct - 12 files only)

### DIFF
--- a/gagents/src/Aevatar.GAgents.GroupChat.Core/Events/CoordinatorEvent.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat.Core/Events/CoordinatorEvent.cs
@@ -56,6 +56,7 @@ public class ChatResponseEvent : EventBase
     [Id(2)] public string MemberName { get; set; }
     [Id(3)] public ChatResponse ChatResponse { get; set; }
     [Id(4)] public long Term { get; set; }
+    [Id(5)] public string FailureSummary { get; set; }
 }
 
 [GenerateSerializer]

--- a/gagents/src/Aevatar.GAgents.GroupChat.Core/Models/WorkUnitExecutionStatus.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat.Core/Models/WorkUnitExecutionStatus.cs
@@ -4,5 +4,6 @@ public enum WorkflowExecutionStatus
 {
     Pending,
     Running,
-    Completed
+    Completed,
+    Failed
 }

--- a/gagents/src/Aevatar.GAgents.GroupChat.Core/States/WorkflowExecutionRecordState.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat.Core/States/WorkflowExecutionRecordState.cs
@@ -39,4 +39,6 @@ public class WorkUnitExecutionRecord
     public string InputData { get; set; }
     [Id(5)]
     public string OutputData { get; set; }
+
+    [Id(6)] public string FailureSummary { get; set; }
 }

--- a/gagents/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/MemberGAgentBase.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat.GroupMember/GAgent/MemberGAgentBase.cs
@@ -5,9 +5,11 @@ using Aevatar.Core;
 using GroupChat.GAgent.Feature.Common;
 using GroupChat.GAgent.GEvent;
 using Aevatar.Core.Abstractions;
+using Aevatar.GAgents.GroupChat.WorkflowCoordinator;
 using GroupChat.GAgent.Dto;
 using GroupChat.GAgent.Feature.Blackboard;
 using GroupChat.GAgent.Feature.Coordinator.GEvent;
+using Microsoft.Extensions.Logging;
 
 namespace GroupChat.GAgent;
 
@@ -40,12 +42,24 @@ public abstract partial class
         }
 
         // var history = await GetCareChatMessagesFromBlackboardAsync(@event.BlackboardId);
-        var talkResponse = await ChatAsync(@event.BlackboardId, @event.CoordinatorMessages);
-        await PublishAsync(new ChatResponseEvent()
+        try
         {
-            BlackboardId = @event.BlackboardId, MemberId = this.GetPrimaryKey(), MemberName = State.MemberName,
-            ChatResponse = talkResponse, Term = @event.Term
-        });
+            var talkResponse = await ChatAsync(@event.BlackboardId, @event.CoordinatorMessages);
+            await PublishAsync(new ChatResponseEvent()
+            {
+                BlackboardId = @event.BlackboardId, MemberId = this.GetPrimaryKey(), MemberName = State.MemberName,
+                ChatResponse = talkResponse, Term = @event.Term
+            });
+        }
+        catch (Exception e)
+        {
+            Logger.LogError($"[MemberGAgentBase] Handler ChatEvent fail: {e.Message}");
+            await PublishAsync(new ChatResponseEvent()
+            {
+                BlackboardId = @event.BlackboardId, MemberId = this.GetPrimaryKey(), MemberName = State.MemberName,
+                FailureSummary = e.ToString(), Term = @event.Term
+            });
+        }
     }
 
     [EventHandler]

--- a/gagents/src/Aevatar.GAgents.GroupChat/GAgent/Coordinator/WorkflowView/WorkflowViewGAgent.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat/GAgent/Coordinator/WorkflowView/WorkflowViewGAgent.cs
@@ -105,6 +105,8 @@ public class WorkflowViewGAgent : GAgentBase<WorkflowViewState, WorkflowViewLogE
                 AgentId = configuration.WorkflowCoordinatorGAgentId
             });
         }
+
+        await ConfirmEvents();
     }
 
     private static bool HasCycle(IReadOnlyCollection<Guid> nodeIds, IEnumerable<WorkflowNodeUnitDto> units)

--- a/gagents/src/Aevatar.GAgents.GroupChat/GroupMemberGAgentBase.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat/GroupMemberGAgentBase.cs
@@ -50,16 +50,31 @@ public abstract class
             return;
         }
 
-        // var history = await GetCareChatMessagesFromBlackboardAsync(@event.BlackboardId);
-        var talkResponse = await ChatAsync(@event.BlackboardId, @event.CoordinatorMessages);
-        await PublishAsync(new ChatResponseEvent
+        try
         {
-            BlackboardId = @event.BlackboardId,
-            MemberId = this.GetPrimaryKey(),
-            MemberName = State.MemberName,
-            ChatResponse = talkResponse,
-            Term = @event.Term
-        });
+            // var history = await GetCareChatMessagesFromBlackboardAsync(@event.BlackboardId);
+            var talkResponse = await ChatAsync(@event.BlackboardId, @event.CoordinatorMessages);
+            await PublishAsync(new ChatResponseEvent
+            {
+                BlackboardId = @event.BlackboardId,
+                MemberId = this.GetPrimaryKey(),
+                MemberName = State.MemberName,
+                ChatResponse = talkResponse,
+                Term = @event.Term
+            });
+        }
+        catch (Exception e)
+        {
+            Logger.LogError($"[GroupMemberGAgentBase] Handler ChatEvent fail: {e.Message}");
+            await PublishAsync(new ChatResponseEvent()
+            {
+                BlackboardId = @event.BlackboardId,
+                MemberId = this.GetPrimaryKey(),
+                MemberName = State.MemberName,
+                FailureSummary = e.ToString(),
+                Term = @event.Term
+            });
+        }
     }
 
     [EventHandler]

--- a/gagents/src/Aevatar.GAgents.GroupChat/WorkflowCoordinatorGAgent.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat/WorkflowCoordinatorGAgent.cs
@@ -53,6 +53,15 @@ public class WorkflowCoordinatorGAgent : GAgentBase<WorkflowCoordinatorState, Wo
             return;
         }
 
+        if (!@event.FailureSummary.IsNullOrEmpty())
+        {
+            Logger.LogError(
+                $"[WorkflowCoordinatorGAgent] ChatResponseEvent workUnit execute fail:{@event.FailureSummary}");
+            RaiseEvent(new WorkflowStartFailedLogEvent());
+            await ConfirmEvents();
+            return;
+        }
+
         var blackboard = GrainFactory.GetGrain<IBlackboardGAgent>(State.BlackboardId);
         await blackboard.SetMessageAsync(new CoordinatorConfirmChatResponse()
         {
@@ -84,7 +93,7 @@ public class WorkflowCoordinatorGAgent : GAgentBase<WorkflowCoordinatorState, Wo
     public async Task HandleEventAsync(StartWorkflowCoordinatorEvent @event)
     {
         Logger.LogDebug("[WorkflowCoordinatorGAgent] handler StartWorkflowCoordinatorEvent start");
-        if (State.WorkflowStatus != WorkflowCoordinatorStatus.Pending)
+        if (State.WorkflowStatus != WorkflowCoordinatorStatus.Pending && State.WorkflowStatus != WorkflowCoordinatorStatus.Failed)
         {
             Logger.LogError("[WorkflowCoordinatorGAgent] The workflow is not ready to run.");
             return;

--- a/gagents/src/Aevatar.GAgents.GroupChat/WorkflowExecutionRecordGAgent.cs
+++ b/gagents/src/Aevatar.GAgents.GroupChat/WorkflowExecutionRecordGAgent.cs
@@ -44,11 +44,23 @@ public class WorkflowExecutionRecordGAgent :
     [EventHandler]
     public async Task HandleEventAsync(ChatResponseEvent @event)
     {
-        RaiseEvent(new FinishExecuteWorkUnitLogEvent
+        if (@event.FailureSummary.IsNullOrEmpty())
         {
-            WorkUnitGrainId = @event.PublisherGrainId.ToString(),
-            OutputData = JsonConvert.SerializeObject(@event.ChatResponse?.Content)
-        });
+            RaiseEvent(new FinishExecuteWorkUnitLogEvent
+            {
+                WorkUnitGrainId = @event.PublisherGrainId.ToString(),
+                OutputData = JsonConvert.SerializeObject(@event.ChatResponse?.Content)
+            });
+        }
+        else
+        {
+            RaiseEvent(new FailExecuteWorkflowLogEvent()
+            {
+                WorkUnitGrainId = @event.PublisherGrainId.ToString(),
+                FailureSummary = @event.FailureSummary
+            });
+        }
+
         await ConfirmEvents();
     }
 
@@ -102,6 +114,15 @@ public class WorkflowExecutionRecordGAgent :
                 workUnit.Status = WorkflowExecutionStatus.Completed;
                 workUnit.OutputData = finishExecuteWorkUnitLogEvent.OutputData;
                 break;
+            case FailExecuteWorkflowLogEvent failExecuteWorkflowLogEvent:
+                var failWorkUnit = state.WorkUnitRecords.First(o =>
+                    o.WorkUnitGrainId == failExecuteWorkflowLogEvent.WorkUnitGrainId);
+                failWorkUnit.EndTime = DateTime.UtcNow;
+                failWorkUnit.Status = WorkflowExecutionStatus.Failed;
+                failWorkUnit.FailureSummary = failExecuteWorkflowLogEvent.FailureSummary;
+
+                state.Status = WorkflowExecutionStatus.Failed;
+                break;
         }
     }
 }
@@ -143,4 +164,13 @@ public class FinishExecuteWorkUnitLogEvent : WorkflowExecutionRecordLogEvent
     public string WorkUnitGrainId { get; set; }
     [Id(1)]
     public string OutputData { get; set; }
+}
+
+[GenerateSerializer]
+public class FailExecuteWorkflowLogEvent : WorkflowExecutionRecordLogEvent
+{
+    [Id(0)]
+    public string WorkUnitGrainId { get; set; }
+    [Id(1)]
+    public string FailureSummary { get; set; }
 }

--- a/gagents/test/Aevatar.GAgents.GroupChat.Test/Aevatar.GAgents.GroupChat.Test.csproj
+++ b/gagents/test/Aevatar.GAgents.GroupChat.Test/Aevatar.GAgents.GroupChat.Test.csproj
@@ -28,6 +28,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\Aevatar.GAgents.Basic\Aevatar.GAgents.Basic.csproj" />
       <ProjectReference Include="..\..\src\Aevatar.GAgents.GroupChat\Aevatar.GAgents.GroupChat.csproj" />
+      <ProjectReference Include="..\..\src\Aevatar.GAgents.InputGAgent\Aevatar.GAgents.InputGAgent.csproj" />
       <ProjectReference Include="..\Aevatar.GAgents.TestBase\Aevatar.GAgents.TestBase.csproj" />
     </ItemGroup>
 

--- a/gagents/test/Aevatar.GAgents.GroupChat.Test/GAgents/WorkerGAgent.cs
+++ b/gagents/test/Aevatar.GAgents.GroupChat.Test/GAgents/WorkerGAgent.cs
@@ -3,6 +3,7 @@ using Aevatar.GAgents.GroupChat.Core.Dto;
 using GroupChat.GAgent;
 using GroupChat.GAgent.Feature.Common;
 using GroupChat.GAgent.GEvent;
+using Volo.Abp;
 
 namespace Aevatar.GAgents.GroupChat.Test.GAgents;
 
@@ -17,6 +18,15 @@ public class WorkerGAgentGAgent : GroupMemberGAgentBase<WorkerState, WorkerEvent
     public async Task SetDelayWorkAsync(int delaySeconds)
     {
         RaiseEvent(new WorkerDelayLogEvent(){DelaySeconds = delaySeconds});
+        await ConfirmEvents();
+    }
+
+    public async Task SetFailureSummary(string failureSummary)
+    {
+        RaiseEvent(new WorkerFailureLogEvent()
+        {
+            FailureSummary = failureSummary
+        });
         await ConfirmEvents();
     }
 
@@ -39,6 +49,11 @@ public class WorkerGAgentGAgent : GroupMemberGAgentBase<WorkerState, WorkerEvent
             await Task.Delay(TimeSpan.FromSeconds(State.DelaySeconds));
         }
 
+        if (!State.FailureSummary.IsNullOrEmpty())
+        {
+            throw new UserFriendlyException(State.FailureSummary);
+        }
+
         var response = new ChatResponse();
         response.Content = $"{State.MemberName} Send the message";
         RaiseEvent(new WorkHandleMessageLogEvent(){ PreWorkUnits = coordinatorMessages!.Select(s=>s.AgentName).ToList()});
@@ -55,6 +70,9 @@ public class WorkerGAgentGAgent : GroupMemberGAgentBase<WorkerState, WorkerEvent
                 return;
             case WorkerDelayLogEvent workerDelayLogEvent:
                 state.DelaySeconds = workerDelayLogEvent.DelaySeconds;
+                return;
+            case WorkerFailureLogEvent workerFailureLogEvent:
+                state.FailureSummary = workerFailureLogEvent.FailureSummary;
                 return;
         }
     }
@@ -78,10 +96,17 @@ public class WorkerDelayLogEvent : WorkerEventLog
     [Id(0)] public int DelaySeconds;
 }
 
+[GenerateSerializer]
+public class WorkerFailureLogEvent : WorkerEventLog
+{
+    [Id(0)] public string FailureSummary;
+}
+
 
 public interface IWorkerGAgent : IStateGAgent<WorkerState>
 {
     Task SetDelayWorkAsync(int delaySeconds);
+    Task SetFailureSummary(string failureSummary);
 }
 
 [GenerateSerializer]
@@ -89,4 +114,5 @@ public class WorkerState : GroupMemberState
 {
     [Id(0)] public List<string> PreWorkUnits = new List<string>();
     [Id(1)] public int DelaySeconds { get; set; } = 0;
+    [Id(2)] public string FailureSummary { get; set; }
 }

--- a/gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/GroupChatWorkflowTest.cs
+++ b/gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/GroupChatWorkflowTest.cs
@@ -6,6 +6,7 @@ using Aevatar.GAgents.GroupChat.WorkflowCoordinator.Dto;
 using Aevatar.GAgents.GroupChat.WorkflowCoordinator.GEvent;
 using Aevatar.GAgents.GroupChat.Test.GAgents;
 using Aevatar.GAgents.GroupChat.WorkflowCoordinator;
+using GroupChat.GAgent.Feature.Coordinator.GEvent;
 using Shouldly;
 
 namespace Aevatar.GAgents.GroupChat.Test.Tests;
@@ -584,5 +585,95 @@ public sealed class GroupChatWorkflowTest : AevatarGroupChatTestBase
         });
         workflowState = await workflowCoordinator.GetStateAsync();
         workflowState.WorkflowStatus.ShouldBe(WorkflowCoordinatorStatus.Pending);
+    }
+
+    [Fact]
+    public async Task Workflow_WithExecutionRecord_Succeeds_ShouldCreateAndCompleteRecord()
+    {
+        var toni = await _agentFactory.GetGAgentAsync<IWorkerGAgent>(Guid.NewGuid());
+        await toni.ConfigAsync(new GroupMemberConfigDto() { MemberName = "Toni" });
+        var leader = await _agentFactory.GetGAgentAsync<ILeaderGAgent>(Guid.NewGuid());
+        await leader.ConfigAsync(new GroupMemberConfigDto() { MemberName = "Leader" });
+
+        var groupAgent = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var workflows = new List<WorkflowUnitDto>()
+        {
+            new WorkflowUnitDto() { GrainId = toni.GetGrainId().ToString(), NextGrainId = leader.GetGrainId().ToString() },
+            new WorkflowUnitDto() { GrainId = leader.GetGrainId().ToString(), NextGrainId = "" }
+        };
+
+        var coordinator = await _agentFactory.GetGAgentAsync<IWorkflowCoordinatorGAgent>(Guid.NewGuid());
+        await coordinator.ConfigAsync(new WorkflowCoordinatorConfigDto
+        {
+            WorkflowUnitList = workflows,
+            InitContent = "init",
+            EnableExecutionRecord = true
+        });
+
+        await groupAgent.RegisterAsync(coordinator);
+        await groupAgent.PublishEventAsync(new StartWorkflowCoordinatorEvent());
+
+        // Wait until execution record id is assigned
+        Guid recordId = Guid.Empty;
+        for (int i = 0; i < 20; i++)
+        {
+            var s = await coordinator.GetStateAsync();
+            recordId = s.CurrentExecutionRecordId;
+            if (recordId != Guid.Empty) break;
+            await Task.Delay(100);
+        }
+        recordId.ShouldNotBe(Guid.Empty);
+
+        // Wait for workflow to finish and record to be unregistered
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        var state = await coordinator.GetStateAsync();
+        state.WorkflowStatus.ShouldBe(WorkflowCoordinatorStatus.Pending);
+        state.CurrentExecutionRecordId.ShouldBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task Workflow_WithExecutionRecord_Failure_ShouldMarkFailed()
+    {
+        var toni = await _agentFactory.GetGAgentAsync<IWorkerGAgent>(Guid.NewGuid());
+        await toni.ConfigAsync(new GroupMemberConfigDto() { MemberName = "Toni" });
+        await toni.SetFailureSummary("Exception");
+        var leader = await _agentFactory.GetGAgentAsync<ILeaderGAgent>(Guid.NewGuid());
+        await leader.ConfigAsync(new GroupMemberConfigDto() { MemberName = "Leader" });
+
+        var groupAgent = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var workflows = new List<WorkflowUnitDto>()
+        {
+            new WorkflowUnitDto() { GrainId = toni.GetGrainId().ToString(), NextGrainId = leader.GetGrainId().ToString() },
+            new WorkflowUnitDto() { GrainId = leader.GetGrainId().ToString(), NextGrainId = "" }
+        };
+
+        var coordinator = await _agentFactory.GetGAgentAsync<IWorkflowCoordinatorGAgent>(Guid.NewGuid());
+        await coordinator.ConfigAsync(new WorkflowCoordinatorConfigDto
+        {
+            WorkflowUnitList = workflows,
+            InitContent = "init",
+            EnableExecutionRecord = true
+        });
+
+        await groupAgent.RegisterAsync(coordinator);
+        await groupAgent.PublishEventAsync(new StartWorkflowCoordinatorEvent());
+
+        // Wait a bit for first unit to be activated and term to be set
+        await Task.Delay(500);
+        // var cstateBefore = await coordinator.GetStateAsync();
+        // var currentTerm = cstateBefore.Term;
+        //
+        // await groupAgent.PublishEventAsync(new ChatResponseEvent
+        // {
+        //     BlackboardId = cstateBefore.BlackboardId,
+        //     MemberId = toni.GetPrimaryKey(),
+        //     MemberName = "Toni",
+        //     FailureSummary = "boom",
+        //     Term = currentTerm
+        // });
+        await Task.Delay(1000);
+
+        var cstate = await coordinator.GetStateAsync();
+        cstate.WorkflowStatus.ShouldBe(WorkflowCoordinatorStatus.Failed);
     }
 }

--- a/gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/WorkflowExecutionRecordGAgentTests.cs
+++ b/gagents/test/Aevatar.GAgents.GroupChat.Test/Tests/WorkflowExecutionRecordGAgentTests.cs
@@ -1,13 +1,21 @@
 using Aevatar.Core.Abstractions;
+using Aevatar.Core;
 using Aevatar.GAgents.Basic.BasicGAgents.GroupGAgent;
 using Aevatar.GAgents.GroupChat.Core;
+using Aevatar.GAgents.GroupChat.Core.Dto;
+using Aevatar.GAgents.GroupChat.Core.States;
 using Aevatar.GAgents.GroupChat.Test.GAgents;
 using Aevatar.GAgents.GroupChat.WorkflowCoordinator;
+using Aevatar.GAgents.GroupChat.WorkflowCoordinator.Dto;
 using Aevatar.GAgents.GroupChat.WorkflowCoordinator.GEvent;
+using GroupChat.GAgent;
 using GroupChat.GAgent.Feature.Common;
 using GroupChat.GAgent.Feature.Coordinator.GEvent;
 using Newtonsoft.Json;
 using Shouldly;
+using Aevatar.GAgents.InputGAgent.GAgent;
+using Aevatar.GAgents.InputGAgent.Dto;
+using Volo.Abp;
 
 namespace Aevatar.GAgents.GroupChat.Test.Tests;
 
@@ -142,6 +150,40 @@ public class WorkflowExecutionRecordGAgentTests : AevatarGroupChatTestBase
     }
 
     [Fact]
+    public async Task Handle_ChatResponseEvent_Failure_Test()
+    {
+        var groupAgent = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var recordAgent = await _agentFactory.GetGAgentAsync<IWorkflowExecutionRecordGAgent>(Guid.NewGuid());
+        await groupAgent.RegisterAsync(recordAgent);
+        var workerGrainId = groupAgent.GetGrainId();
+
+        await StartExecuteWorkflowAsync(groupAgent, workerGrainId);
+
+        var startExecuteGrain = new StartExecuteWorkUnitEvent
+        {
+            WorkUnitGrainId = workerGrainId.ToString(),
+            CoordinatorMessages = new List<ChatMessage> { new ChatMessage { Content = "Input A" } }
+        };
+        await groupAgent.PublishEventAsync(startExecuteGrain);
+        await Task.Delay(500);
+
+        var failure = new ChatResponseEvent
+        {
+            PublisherGrainId = workerGrainId,
+            FailureSummary = "unit crashed"
+        };
+        await groupAgent.PublishEventAsync(failure);
+        await Task.Delay(1000);
+
+        var state = await recordAgent.GetStateAsync();
+        state.Status.ShouldBe(WorkflowExecutionStatus.Failed);
+        var unit = state.WorkUnitRecords.First(o => o.WorkUnitGrainId == workerGrainId.ToString());
+        unit.Status.ShouldBe(WorkflowExecutionStatus.Failed);
+        unit.FailureSummary.ShouldBe("unit crashed");
+        unit.EndTime.ShouldNotBeNull();
+    }
+
+    [Fact]
     public async Task IncorrectSequence_Test()
     {
         var groupAgent = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
@@ -199,5 +241,363 @@ public class WorkflowExecutionRecordGAgentTests : AevatarGroupChatTestBase
 
         await groupAgent.PublishEventAsync(startExecuteWorkflowEvent);
         await Task.Delay(1000);
+    }
+
+    [Fact]
+    public async Task Member_GetDescription_ShouldIncludeMemberName()
+    {
+        var member = await _agentFactory.GetGAgentAsync<ITestMemberHelperGAgent>(Guid.NewGuid());
+        await member.ConfigAsync(new GroupMemberConfigDto { MemberName = "Alice" });
+
+        var desc = await member.DescribeAsync();
+        desc.ShouldContain("Member Name: Alice");
+    }
+
+    [Fact]
+    public async Task Member_Ping_ShouldPublishPong()
+    {
+        var group = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var member = await _agentFactory.GetGAgentAsync<ITestMemberHelperGAgent>(Guid.NewGuid());
+        await member.ConfigAsync(new GroupMemberConfigDto { MemberName = "Pingy" });
+        var collector = await _agentFactory.GetGAgentAsync<IEventCollectorGAgent>(Guid.NewGuid());
+
+        await group.RegisterAsync(member);
+        await group.RegisterAsync(collector);
+
+        var blackboardId = Guid.NewGuid();
+        await group.PublishEventAsync(new CoordinatorPingEvent { BlackboardId = blackboardId });
+        await Task.Delay(500);
+
+        var s = await collector.GetStateAsync();
+        s.LastPongBlackboardId.ShouldBe(blackboardId);
+        s.LastPongMemberName.ShouldBe("Pingy");
+        s.LastPongMemberId.ShouldBe(member.GetGrainId().GetGuidKey());
+    }
+
+    [Fact]
+    public async Task Member_EvaluationInterest_ShouldPublishResponse()
+    {
+        var group = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var member = await _agentFactory.GetGAgentAsync<ITestMemberHelperGAgent>(Guid.NewGuid());
+        await member.ConfigAsync(new GroupMemberConfigDto { MemberName = "Eva" });
+        var collector = await _agentFactory.GetGAgentAsync<IEventCollectorGAgent>(Guid.NewGuid());
+
+        await group.RegisterAsync(member);
+        await group.RegisterAsync(collector);
+
+        var blackboardId = Guid.NewGuid();
+        await group.PublishEventAsync(new EvaluationInterestEvent { BlackboardId = blackboardId, ChatTerm = 123 });
+        await Task.Delay(500);
+
+        var s = await collector.GetStateAsync();
+        s.LastInterestBlackboardId.ShouldBe(blackboardId);
+        s.LastInterestMemberId.ShouldBe(member.GetGrainId().GetGuidKey());
+        s.LastInterestValue.ShouldBe(77);
+        s.LastInterestChatTerm.ShouldBe(123);
+    }
+
+    [Fact]
+    public async Task Member_GetMessageFromBlackboard_ShouldReturnContent()
+    {
+        var member = await _agentFactory.GetGAgentAsync<ITestMemberHelperGAgent>(Guid.NewGuid());
+        await member.ConfigAsync(new GroupMemberConfigDto { MemberName = "Reader" });
+
+        var blackboardId = Guid.NewGuid();
+        var blackboard = await _agentFactory.GetGAgentAsync<IBlackboardGAgent>(blackboardId);
+        await blackboard.SetTopic("topic-x");
+
+        var msgs = await member.FetchBlackboardMessages(blackboardId);
+        msgs.ShouldNotBeNull();
+        msgs.Any(m => m.MessageType == MessageType.BlackboardTopic && m.Content == "topic-x").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task InputGAgent_ChatEvent_SpeakerMatch_ShouldPublishChatResponse()
+    {
+        var group = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var input = await _agentFactory.GetGAgentAsync<IInputGAgent>(Guid.NewGuid());
+        var collector = await _agentFactory.GetGAgentAsync<IEventCollectorGAgent>(Guid.NewGuid());
+
+        await group.RegisterAsync(input);
+        await group.RegisterAsync(collector);
+
+        await input.ConfigAsync(new InputConfigDto { MemberName = "Inny", Input = "Hello" });
+
+        var blackboardId = Guid.NewGuid();
+        await group.PublishEventAsync(new ChatEvent
+        {
+            BlackboardId = blackboardId,
+            Speaker = input.GetGrainId().GetGuidKey(),
+            Term = 1,
+            CoordinatorMessages = new List<ChatMessage> { new ChatMessage { Content = "start" } }
+        });
+
+        await Task.Delay(500);
+
+        var s = await collector.GetStateAsync();
+        s.LastChatBlackboardId.ShouldBe(blackboardId);
+        s.LastChatMemberId.ShouldBe(input.GetGrainId().GetGuidKey());
+        s.LastChatMemberName.ShouldBe("Inny");
+        s.LastChatContent.ShouldBe("Hello");
+        s.LastChatTerm.ShouldBe(1);
+        s.LastChatFailure.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task InputGAgent_ChatEvent_SpeakerMismatch_ShouldBeIgnored()
+    {
+        var group = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var input = await _agentFactory.GetGAgentAsync<IInputGAgent>(Guid.NewGuid());
+        var collector = await _agentFactory.GetGAgentAsync<IEventCollectorGAgent>(Guid.NewGuid());
+
+        await group.RegisterAsync(input);
+        await group.RegisterAsync(collector);
+
+        await input.ConfigAsync(new InputConfigDto { MemberName = "Inny", Input = "Hello" });
+
+        var blackboardId = Guid.NewGuid();
+        await group.PublishEventAsync(new ChatEvent
+        {
+            BlackboardId = blackboardId,
+            Speaker = Guid.NewGuid(),
+            Term = 2,
+            CoordinatorMessages = new List<ChatMessage> { new ChatMessage { Content = "start" } }
+        });
+
+        await Task.Delay(500);
+
+        var s = await collector.GetStateAsync();
+        s.LastChatBlackboardId.ShouldNotBe(blackboardId);
+        s.LastChatContent.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task InputGAgent_EvaluationInterest_ShouldPublish100()
+    {
+        var group = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var input = await _agentFactory.GetGAgentAsync<IInputGAgent>(Guid.NewGuid());
+        var collector = await _agentFactory.GetGAgentAsync<IEventCollectorGAgent>(Guid.NewGuid());
+
+        await group.RegisterAsync(input);
+        await group.RegisterAsync(collector);
+
+        await input.ConfigAsync(new InputConfigDto { MemberName = "Scorer", Input = "whatever" });
+
+        var blackboardId = Guid.NewGuid();
+        await group.PublishEventAsync(new EvaluationInterestEvent { BlackboardId = blackboardId, ChatTerm = 9 });
+        await Task.Delay(500);
+
+        var s = await collector.GetStateAsync();
+        s.LastInterestBlackboardId.ShouldBe(blackboardId);
+        s.LastInterestMemberId.ShouldBe(input.GetGrainId().GetGuidKey());
+        s.LastInterestValue.ShouldBe(100);
+        s.LastInterestChatTerm.ShouldBe(9);
+    }
+
+    [Fact]
+    public async Task Workflow_WithExecutionRecord_Failure_ShouldMarkFailed()
+    {
+        var toni = await _agentFactory.GetGAgentAsync<IFailInputGAgent>(Guid.NewGuid());
+        await toni.ConfigAsync(new InputConfigDto { MemberName = "Scorer", Input = "whatever" });
+        var leader = await _agentFactory.GetGAgentAsync<ILeaderGAgent>(Guid.NewGuid());
+        await leader.ConfigAsync(new GroupMemberConfigDto() { MemberName = "Leader" });
+
+        var groupAgent = await _agentFactory.GetGAgentAsync<IGroupGAgent>(Guid.NewGuid());
+        var workflows = new List<WorkflowUnitDto>()
+        {
+            new WorkflowUnitDto() { GrainId = toni.GetGrainId().ToString(), NextGrainId = leader.GetGrainId().ToString() },
+            new WorkflowUnitDto() { GrainId = leader.GetGrainId().ToString(), NextGrainId = "" }
+        };
+
+        var coordinator = await _agentFactory.GetGAgentAsync<IWorkflowCoordinatorGAgent>(Guid.NewGuid());
+        await coordinator.ConfigAsync(new WorkflowCoordinatorConfigDto
+        {
+            WorkflowUnitList = workflows,
+            InitContent = "init",
+            EnableExecutionRecord = true
+        });
+
+        await groupAgent.RegisterAsync(coordinator);
+        await groupAgent.PublishEventAsync(new StartWorkflowCoordinatorEvent());
+
+        // Wait a bit for first unit to be activated and term to be set
+        await Task.Delay(1500);
+
+        var cstate = await coordinator.GetStateAsync();
+        cstate.WorkflowStatus.ShouldBe(WorkflowCoordinatorStatus.Failed);
+    }
+
+    // Test helper agents for coverage
+    [GAgent(nameof(EventCollectorGAgent))]
+    public class EventCollectorGAgent : GroupMemberGAgentBase<CollectorState, CollectorLogEvent, EventBase, GroupMemberConfigDto>, IEventCollectorGAgent
+    {
+        public override Task<string> GetDescriptionAsync() => Task.FromResult("collector");
+
+        protected override Task<int> GetInterestValueAsync(Guid blackboardId) => Task.FromResult(0);
+
+        protected override Task<ChatResponse> ChatAsync(Guid blackboardId, List<ChatMessage>? coordinatorMessages)
+        {
+            return Task.FromResult(new ChatResponse { Content = "noop" });
+        }
+
+        [EventHandler]
+        public async Task HandleEventAsync(CoordinatorPongEvent @event)
+        {
+            RaiseEvent(new SetPongLogEvent
+            {
+                BlackboardId = @event.BlackboardId,
+                MemberId = @event.MemberId,
+                MemberName = @event.MemberName
+            });
+            await ConfirmEvents();
+        }
+
+        [EventHandler]
+        public async Task HandleEventAsync(EvaluationInterestResponseEvent @event)
+        {
+            RaiseEvent(new SetInterestLogEvent
+            {
+                BlackboardId = @event.BlackboardId,
+                MemberId = @event.MemberId,
+                InterestValue = @event.InterestValue,
+                ChatTerm = @event.ChatTerm
+            });
+            await ConfirmEvents();
+        }
+
+        [EventHandler]
+        public async Task HandleEventAsync(ChatResponseEvent @event)
+        {
+            RaiseEvent(new SetChatLogEvent
+            {
+                BlackboardId = @event.BlackboardId,
+                MemberId = @event.MemberId,
+                MemberName = @event.MemberName,
+                Content = @event.ChatResponse?.Content,
+                Term = @event.Term,
+                Failure = @event.FailureSummary
+            });
+            await ConfirmEvents();
+        }
+
+        protected override void GroupMemberTransitionState(CollectorState state, StateLogEventBase<CollectorLogEvent> @event)
+        {
+            switch (@event)
+            {
+                case SetPongLogEvent e:
+                    state.LastPongBlackboardId = e.BlackboardId;
+                    state.LastPongMemberId = e.MemberId;
+                    state.LastPongMemberName = e.MemberName;
+                    return;
+                case SetInterestLogEvent e2:
+                    state.LastInterestBlackboardId = e2.BlackboardId;
+                    state.LastInterestMemberId = e2.MemberId;
+                    state.LastInterestValue = e2.InterestValue;
+                    state.LastInterestChatTerm = e2.ChatTerm;
+                    return;
+                case SetChatLogEvent e3:
+                    state.LastChatBlackboardId = e3.BlackboardId;
+                    state.LastChatMemberId = e3.MemberId;
+                    state.LastChatMemberName = e3.MemberName;
+                    state.LastChatContent = e3.Content;
+                    state.LastChatTerm = e3.Term;
+                    state.LastChatFailure = e3.Failure;
+                    return;
+            }
+        }
+    }
+
+    public interface IEventCollectorGAgent : IStateGAgent<CollectorState>
+    {
+    }
+
+    [GenerateSerializer]
+    public class CollectorLogEvent : StateLogEventBase<CollectorLogEvent>
+    {
+    }
+
+    [GenerateSerializer]
+    public class SetPongLogEvent : CollectorLogEvent
+    {
+        [Id(0)] public Guid BlackboardId { get; set; }
+        [Id(1)] public Guid MemberId { get; set; }
+        [Id(2)] public string MemberName { get; set; }
+    }
+
+    [GenerateSerializer]
+    public class SetInterestLogEvent : CollectorLogEvent
+    {
+        [Id(0)] public Guid BlackboardId { get; set; }
+        [Id(1)] public Guid MemberId { get; set; }
+        [Id(2)] public int InterestValue { get; set; }
+        [Id(3)] public long ChatTerm { get; set; }
+    }
+
+    [GenerateSerializer]
+    public class SetChatLogEvent : CollectorLogEvent
+    {
+        [Id(0)] public Guid BlackboardId { get; set; }
+        [Id(1)] public Guid MemberId { get; set; }
+        [Id(2)] public string MemberName { get; set; }
+        [Id(3)] public string Content { get; set; }
+        [Id(4)] public long Term { get; set; }
+        [Id(5)] public string Failure { get; set; }
+    }
+
+    [GenerateSerializer]
+    public class CollectorState : WorkerState
+    {
+        [Id(10)] public Guid LastPongBlackboardId { get; set; }
+        [Id(11)] public Guid LastPongMemberId { get; set; }
+        [Id(12)] public string LastPongMemberName { get; set; }
+        [Id(13)] public Guid LastInterestBlackboardId { get; set; }
+        [Id(14)] public Guid LastInterestMemberId { get; set; }
+        [Id(15)] public int LastInterestValue { get; set; }
+        [Id(16)] public long LastInterestChatTerm { get; set; }
+        [Id(17)] public Guid LastChatBlackboardId { get; set; }
+        [Id(18)] public Guid LastChatMemberId { get; set; }
+        [Id(19)] public string LastChatMemberName { get; set; }
+        [Id(20)] public string LastChatContent { get; set; }
+        [Id(21)] public long LastChatTerm { get; set; }
+        [Id(22)] public string LastChatFailure { get; set; }
+    }
+
+    [GAgent(nameof(TestMemberHelperGAgent))]
+    public class TestMemberHelperGAgent : GroupMemberGAgentBase<WorkerState, TestMemberEventLog, EventBase, GroupMemberConfigDto>, ITestMemberHelperGAgent
+    {
+        protected override Task<int> GetInterestValueAsync(Guid blackboardId) => Task.FromResult(77);
+
+        protected override Task<ChatResponse> ChatAsync(Guid blackboardId, List<ChatMessage>? coordinatorMessages)
+        {
+            return Task.FromResult(new ChatResponse { Content = "ok" });
+        }
+
+        public Task<List<ChatMessage>> FetchBlackboardMessages(Guid blackboardId) => GetMessageFromBlackboardAsync(blackboardId);
+
+        public Task<string> DescribeAsync() => GetDescriptionAsync();
+    }
+
+    public interface ITestMemberHelperGAgent : IStateGAgent<WorkerState>
+    {
+        Task<List<ChatMessage>> FetchBlackboardMessages(Guid blackboardId);
+        Task<string> DescribeAsync();
+    }
+
+    [GenerateSerializer]
+    public class TestMemberEventLog : StateLogEventBase<TestMemberEventLog>
+    {
+    }
+
+    [GAgent(nameof(FailInputGAgent))]
+    public class FailInputGAgent : InputGAgent.GAgent.InputGAgent, IFailInputGAgent
+    {
+        protected override Task<ChatResponse> ChatAsync(Guid blackboardId, List<ChatMessage>? messages)
+        {
+            throw new UserFriendlyException("InputGAgent fail");
+        }
+    }
+
+    public interface IFailInputGAgent : IInputGAgent
+    {
     }
 }


### PR DESCRIPTION
Migrated from aevatarAI/aevatar-gagents#160

## Summary
This is the **correct** migration of PR #160 with exactly 12 files as per the original PR.

**Previous PR #1380 incorrectly included 23 files including unrelated PsiOmni changes.**

## Changes in this PR (12 files total)
### Core Changes (3 files)
-  - Added FailureSummary property
-  - Added Failed status
-  - Added failure tracking

### Implementation (5 files)
-  - Failure handling
-  - Added ConfirmEvents
-  - Enhanced failure response
-  - Failure summary propagation
-  - Failure recording

### Tests (4 files)
-  - Test dependencies
-  - Test worker with failure simulation
-  - Failure scenario tests
-  - Unit tests

## Testing
- ✅ Build successful
- ✅ All 27 GroupChat tests pass
- ✅ Verified exactly 12 files changed

Closes #1380 (incorrect migration)