### PR TITLE
fix: unify benchmark P95 thresholds with separate configurations

### DIFF
--- a/.github/workflows/regression-test-ephemeral-env.yaml
+++ b/.github/workflows/regression-test-ephemeral-env.yaml
@@ -453,6 +453,7 @@ jobs:
       BCAST_PUBS: "1"
       BCAST_DURATION: "300"
       BCAST_WARMUP: "5"
+      BCAST_P95_TARGET: "140"
 
     steps:
       - name: Checkout code
@@ -552,7 +553,7 @@ jobs:
                     value: "$BCAST_EPS"
                   # Common thresholds
                   - name: COMMON_P95_TARGET
-                    value: "120"
+                    value: "$BCAST_P95_TARGET"
                   # Broadcast benchmark parameters
                   - name: BCAST_SUBS
                     value: "$BCAST_SUBS"
@@ -672,7 +673,7 @@ jobs:
             
             # Set thresholds
             success_rate_target="90.0"
-            p95_target="140"
+            p95_target="$BCAST_P95_TARGET"
             
             echo "### 📊 Broadcast Latency Benchmark" >> $GITHUB_STEP_SUMMARY
             echo "**Test Parameters:** Subscribers: ${subscribers}, Publishers: ${publishers}, EPS: ${eps}, Duration: ${duration}s, Warmup: ${warmup}s" >> $GITHUB_STEP_SUMMARY
@@ -772,6 +773,7 @@ jobs:
       LAT_WARMUP: "5"
       LAT_START_FROM_LEVEL: "16"
       LAT_STOP_AT_LEVEL: "16"
+      LAT_P95_TARGET: "120"
 
     steps:
       - name: Check Broadcast Benchmark Status
@@ -877,7 +879,7 @@ jobs:
                     value: "$LAT_EPS"
                   # Common thresholds
                   - name: COMMON_P95_TARGET
-                    value: "120"
+                    value: "$LAT_P95_TARGET"
                   # Latency benchmark parameters
                   - name: LAT_MAX_CONCURRENCY
                     value: "$LAT_MAX_CONCURRENCY"
@@ -1002,7 +1004,7 @@ jobs:
             warmup="$LAT_WARMUP"
             
             # Set thresholds
-            p95_target="120"
+            p95_target="$LAT_P95_TARGET"
             p99_target="1000"
             processed_ratio_target="100.0"
             


### PR DESCRIPTION
- Add BCAST_P95_TARGET (140ms) for broadcast benchmark
- Add LAT_P95_TARGET (120ms) for latency benchmark